### PR TITLE
Update & Fix Japanese translate.

### DIFF
--- a/src/translations/apk-editor-studio.ja.ts
+++ b/src/translations/apk-editor-studio.ja.ts
@@ -1122,7 +1122,7 @@ Do you want to discard them and exit?</source>
     </message>
     <message>
       <source>Cloning the APK requires the source code decompilation to be turned on. Proceed?</source>
-      <translation>APK をクローンするには、ソースコードの逆コンパイルをオンにする必要があります。続行しますか？</translation>
+      <translation>APK をクローンするには、ソースコードのデコンパイルをオンにする必要があります。続行しますか？</translation>
     </message>
     <message>
       <source>Settings have been applied. Please, reopen this APK.</source>

--- a/src/translations/apk-editor-studio.ja.ts
+++ b/src/translations/apk-editor-studio.ja.ts
@@ -1607,7 +1607,7 @@ Any unsaved changes will be lost.</source>
     <message>
       <source>Array</source>
       <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#TypedArray).</extracomment>
-      <translation>配列</translation>
+      <translation>Array</translation>
     </message>
   </context>
   <context>

--- a/src/translations/apk-editor-studio.ja.ts
+++ b/src/translations/apk-editor-studio.ja.ts
@@ -383,7 +383,7 @@
     </message>
     <message>
       <source>Serial Number</source>
-      <translation>シリアルナンバー</translation>
+      <translation>シリアル番号</translation>
     </message>
     <message>
       <source>Product</source>

--- a/src/translations/apk-editor-studio.ja.ts
+++ b/src/translations/apk-editor-studio.ja.ts
@@ -1,1619 +1,1621 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
-<context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja" sourcelanguage="en">
+  <context>
     <name>AboutDialog</name>
     <message>
-        <source>About</source>
-        <translation>情報</translation>
+      <source>About</source>
+      <translation>バージョン情報</translation>
     </message>
     <message>
-        <source>Authors</source>
-        <translation>作者</translation>
+      <source>Authors</source>
+      <translation>作者</translation>
     </message>
     <message>
-        <source>Donations</source>
-        <translation>寄付</translation>
+      <source>Donations</source>
+      <translation>寄付</translation>
     </message>
     <message>
-        <source>Version History</source>
-        <translation>更新履歴</translation>
+      <source>Version History</source>
+      <translation>バージョン履歴</translation>
     </message>
     <message>
-        <source>Technologies</source>
-        <translation>テクノロジー</translation>
+      <source>Technologies</source>
+      <translation>テクノロジー</translation>
     </message>
     <message>
-        <source>License</source>
-        <translation>ライセンス</translation>
+      <source>License</source>
+      <translation>ライセンス</translation>
     </message>
     <message>
-        <source>Author:</source>
-        <translation>作者:</translation>
+      <source>Author:</source>
+      <translation>作者:</translation>
     </message>
     <message>
-        <source>Website:</source>
-        <translation>ウェブサイト:</translation>
+      <source>Website:</source>
+      <translation>ウェブサイト:</translation>
     </message>
     <message>
-        <source>Bug Tracker:</source>
-        <translation>バグトラッカー:</translation>
+      <source>Bug Tracker:</source>
+      <translation>バグトラッカー:</translation>
     </message>
     <message>
-        <source>Translation:</source>
-        <translation>翻訳:</translation>
+      <source>Translation:</source>
+      <translation>翻訳:</translation>
     </message>
     <message>
-        <source>Could not fetch the list of donations.</source>
-        <translation>寄付のリストを取得できませんでした。</translation>
+      <source>Could not fetch the list of donations.</source>
+      <translation>寄付の一覧を取得できませんでした。</translation>
     </message>
     <message>
-        <source>Retry</source>
-        <translation>リトライ</translation>
+      <source>Retry</source>
+      <translation>再試行</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ActionProvider</name>
     <message>
-        <source>Are you sure you want to reset settings?</source>
-        <translation>設定をリセットしてもよろしいですか？</translation>
+      <source>Are you sure you want to reset settings?</source>
+      <translation>設定をリセットしてもよろしいですか？</translation>
     </message>
     <message>
-        <source>Screenshot has been successfully created!</source>
-        <translation>スクリーンショットが正常に作成されました！</translation>
+      <source>Screenshot has been successfully created!</source>
+      <translation>スクリーンショットは正常に作成されました！</translation>
     </message>
     <message>
-        <source>Could not take a screenshot.</source>
-        <translation>スクリーンショットを撮ることができませんでした。</translation>
+      <source>Could not take a screenshot.</source>
+      <translation>スクリーンショットを撮影できませんでした。</translation>
     </message>
     <message>
-        <source>&amp;Optimize External APK...</source>
-        <translation>&amp;外部APKの最適化...</translation>
+      <source>&amp;Optimize External APK...</source>
+      <translation>外部 APK を最適化(&amp;O)...</translation>
     </message>
     <message>
-        <source>&amp;Sign External APK...</source>
-        <translation>&amp;外部APKの署名...</translation>
+      <source>&amp;Sign External APK...</source>
+      <translation>外部 APK を署名(&amp;S)...</translation>
     </message>
     <message>
-        <source>&amp;Install External APK...</source>
-        <translation>&amp;外部 APK をインストール..</translation>
+      <source>&amp;Install External APK...</source>
+      <translation>外部 APK をインストール(&amp;I)...</translation>
     </message>
     <message>
-        <source>&amp;Find</source>
-        <translation>&amp;探す</translation>
+      <source>&amp;Find</source>
+      <translation>検索(&amp;F)</translation>
     </message>
     <message>
-        <source>Find &amp;Next</source>
-        <translation>&amp;次を検索</translation>
+      <source>Find &amp;Next</source>
+      <translation>次を検索(&amp;N)</translation>
     </message>
     <message>
-        <source>Find Pre&amp;vious</source>
-        <translation>&amp;前を検索</translation>
+      <source>Find Pre&amp;vious</source>
+      <translation>前を検索(&amp;V)</translation>
     </message>
     <message>
-        <source>Find and &amp;Replace</source>
-        <translation>検索して置換</translation>
+      <source>Find and &amp;Replace</source>
+      <translation>検索と置換(&amp;R)</translation>
     </message>
     <message>
-        <source>Zoom In</source>
-        <translation>ズームイン</translation>
+      <source>Zoom In</source>
+      <translation>拡大</translation>
     </message>
     <message>
-        <source>Zoom Out</source>
-        <translation>ズームアウト</translation>
+      <source>Zoom Out</source>
+      <translation>縮小</translation>
     </message>
     <message>
-        <source>Reset Zoom</source>
-        <translation>ズームをリセットする</translation>
+      <source>Reset Zoom</source>
+      <translation>拡大をリセット</translation>
     </message>
     <message>
-        <source>Visit &amp;Website</source>
-        <translation>サイトを訪問</translation>
+      <source>Visit &amp;Website</source>
+      <translation>ウェブサイトを開く(&amp;W)</translation>
     </message>
     <message>
-        <source>&amp;Source Code</source>
-        <translation>&amp;ソースコード</translation>
+      <source>&amp;Source Code</source>
+      <translation>ソースコード(&amp;S)</translation>
     </message>
     <message>
-        <source>Make a &amp;Donation</source>
-        <translation>寄付&amp;する</translation>
+      <source>Make a &amp;Donation</source>
+      <translation>寄付をする(&amp;D)</translation>
     </message>
     <message>
-        <source>E&amp;xit</source>
-        <translation>閉じる</translation>
+      <source>E&amp;xit</source>
+      <translation>終了(&amp;X)</translation>
     </message>
     <message>
-        <source>Check for &amp;Updates</source>
-        <translation>更新を確認</translation>
+      <source>Check for &amp;Updates</source>
+      <translation>更新を確認する(&amp;U)</translation>
     </message>
     <message>
-        <source>&amp;Reset Settings...</source>
-        <translation>&amp;設定をリセット...</translation>
+      <source>&amp;Reset Settings...</source>
+      <translation>設定をリセット(&amp;R)...</translation>
     </message>
     <message>
-        <source>&amp;Options...</source>
-        <translation>&amp;オプション...</translation>
+      <source>&amp;Options...</source>
+      <translation>オプション(&amp;O)...</translation>
     </message>
     <message>
-        <source>&amp;Device Manager...</source>
-        <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
-        <translation>&amp;デバイスマネージャ...</translation>
+      <source>&amp;Device Manager...</source>
+      <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
+      <translation>デバイスマネージャー(&amp;D)...</translation>
     </message>
     <message>
-        <source>&amp;Key Manager...</source>
-        <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
-        <translation>&amp;キーマネージャー...</translation>
+      <source>&amp;Key Manager...</source>
+      <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
+      <translation>キーマネージャー(&amp;K)...</translation>
     </message>
     <message>
-        <source>&amp;Android Explorer...</source>
-        <translation>&amp;Android Explorer...</translation>
+      <source>&amp;Android Explorer...</source>
+      <translation>Android エクスプローラー(&amp;A)...</translation>
     </message>
     <message>
-        <source>Take &amp;Screenshot...</source>
-        <translation>撮影＆スクリーンショット...</translation>
+      <source>Take &amp;Screenshot...</source>
+      <translation>スクリーンショットを撮影(&amp;S)...</translation>
     </message>
     <message>
-        <source>&amp;Language</source>
-        <translation>&amp;言語</translation>
+      <source>&amp;Language</source>
+      <translation>言語(&amp;L)</translation>
     </message>
     <message>
-        <source>&amp;Open APK...</source>
-        <translation>APKを開く...</translation>
+      <source>&amp;Open APK...</source>
+      <translation>APK を開く(&amp;O)...</translation>
     </message>
     <message>
-        <source>Case Sensitive</source>
-        <translation>ケースセンシティブ</translation>
+      <source>Case Sensitive</source>
+      <translation>大文字と小文字を区別する</translation>
     </message>
     <message>
-        <source>Regular Expression</source>
-        <translation>正規表現</translation>
+      <source>Regular Expression</source>
+      <translation>正規表現</translation>
     </message>
     <message>
-        <source>&amp;Framework Manager...</source>
-        <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
-        <translation>&amp;Framework Manager...</translation>
+      <source>&amp;Framework Manager...</source>
+      <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
+      <translation>フレームワークマネージャー(&amp;F)...</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>AndroidExplorer</name>
     <message>
-        <source>Android Explorer</source>
-        <translation>Android Explorer</translation>
+      <source>Android Explorer</source>
+      <translation>Android エクスプローラー</translation>
     </message>
     <message>
-        <source>Are you sure you want to delete this file?</source>
-        <translation>本当にこのファイルを削除していいですか？</translation>
+      <source>Are you sure you want to delete this file?</source>
+      <translation>このファイルを削除してもよろしいですか？</translation>
     </message>
     <message>
-        <source>Are you sure you want to delete this directory?</source>
-        <translation>本当にこのディレクトリを削除していいのですか？</translation>
+      <source>Are you sure you want to delete this directory?</source>
+      <translation>このディレクトリを削除してもよろしいですか？</translation>
     </message>
     <message>
-        <source>Installing %1...</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
-        <translation>をインストールしています。 %1...</translation>
+      <source>Installing %1...</source>
+      <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
+      <translation>%1 をインストール中です...</translation>
     </message>
     <message>
-        <source>Successfully installed %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
-        <translation>インストールに成功しました %1</translation>
+      <source>Successfully installed %1</source>
+      <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
+      <translation>%1 のインストールに成功しました</translation>
     </message>
     <message>
-        <source>Could not install %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
-        <translation> をインストールできませんでした。 %1</translation>
+      <source>Could not install %1</source>
+      <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
+      <translation>%1 をインストールできませんでした</translation>
     </message>
     <message>
-        <source>Download</source>
-        <translation>ダウンロード</translation>
+      <source>Download</source>
+      <translation>ダウンロード</translation>
     </message>
     <message>
-        <source>Upload</source>
-        <translation>アップロード</translation>
+      <source>Upload</source>
+      <translation>アップロード</translation>
     </message>
     <message>
-        <source>Copy</source>
-        <translation>コピー</translation>
+      <source>Copy</source>
+      <translation>コピー</translation>
     </message>
     <message>
-        <source>Cut</source>
-        <translation>カット</translation>
+      <source>Cut</source>
+      <translation>切り取り</translation>
     </message>
     <message>
-        <source>Paste</source>
-        <translation>貼り付け</translation>
+      <source>Paste</source>
+      <translation>貼り付け</translation>
     </message>
     <message>
-        <source>Rename</source>
-        <translation>名前を変更</translation>
+      <source>Rename</source>
+      <translation>名前を変更</translation>
     </message>
     <message>
-        <source>Delete</source>
-        <translation>削除</translation>
+      <source>Delete</source>
+      <translation>削除</translation>
     </message>
     <message>
-        <source>Up</source>
-        <extracomment>Navigate up one directory in a file manager hierarchy.</extracomment>
-        <translation>アップ</translation>
+      <source>Up</source>
+      <extracomment>Navigate up one directory in a file manager hierarchy.</extracomment>
+      <translation>上へ</translation>
     </message>
     <message>
-        <source>Go</source>
-        <extracomment>Navigate to a directory in a file manager.</extracomment>
-        <translation>Go</translation>
+      <source>Go</source>
+      <extracomment>Navigate to a directory in a file manager.</extracomment>
+      <translation>移動</translation>
     </message>
     <message>
-        <source>Tasks</source>
-        <translation>Tasks</translation>
+      <source>Tasks</source>
+      <translation>タスク</translation>
     </message>
     <message>
-        <source>&amp;Edit</source>
-        <extracomment>Refers to a menu bar (along with File, View, Window, Help, and similar items).</extracomment>
-        <translation>&amp;編集</translation>
+      <source>&amp;Edit</source>
+      <extracomment>Refers to a menu bar (along with File, View, Window, Help, and similar items).</extracomment>
+      <translation>編集(&amp;E)</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>AndroidFileSystemModel</name>
     <message>
-        <source>Could not open the directory.</source>
-        <translation>ディレクトリを開くことができませんでした。</translation>
+      <source>Could not open the directory.</source>
+      <translation>ディレクトリを開けませんでした。</translation>
     </message>
     <message>
-        <source>Could not copy the file or directory.</source>
-        <translation>ファイルまたはディレクトリをコピーできませんでした。</translation>
+      <source>Could not copy the file or directory.</source>
+      <translation>ファイルまたはディレクトリをコピーできませんでした。</translation>
     </message>
     <message>
-        <source>Could not move the file or directory.</source>
-        <translation>ファイルまたはディレクトリを移動できませんでした。</translation>
+      <source>Could not move the file or directory.</source>
+      <translation>ファイルまたはディレクトリを移動できませんでした。</translation>
     </message>
     <message>
-        <source>Could not rename the file or directory.</source>
-        <translation>ファイルまたはディレクトリの名前を変更できませんでした。</translation>
+      <source>Could not rename the file or directory.</source>
+      <translation>ファイルまたはディレクトリの名前を変更できませんでした。</translation>
     </message>
     <message>
-        <source>Could not delete the file or directory.</source>
-        <translation>ファイルまたはディレクトリを削除できませんでした。</translation>
+      <source>Could not delete the file or directory.</source>
+      <translation>ファイルまたはディレクトリを削除できませんでした。</translation>
     </message>
     <message>
-        <source>Could not download the file or directory.</source>
-        <translation>ファイルまたはディレクトリをダウンロードできませんでした。</translation>
+      <source>Could not download the file or directory.</source>
+      <translation>ファイルまたはディレクトリをダウンロードできませんでした。</translation>
     </message>
     <message>
-        <source>Could not upload the file.</source>
-        <translation>ファイルをアップロードできませんでした。</translation>
+      <source>Could not upload the file.</source>
+      <translation>ファイルをアップロードできませんでした。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ApkCloner</name>
     <message>
-        <source>Updating resource references...</source>
-        <translation>リソースリファレンスを更新する...</translation>
+      <source>Updating resource references...</source>
+      <translation>リソースリファレンスを更新中です...</translation>
     </message>
     <message>
-        <source>Updating Smali references...</source>
-        <extracomment>&quot;Smali&quot; is the name of the tool/format, don't translate it.</extracomment>
-        <translation>Smaliのリファレンスを更新しています...</translation>
+      <source>Updating Smali references...</source>
+      <extracomment>&quot;Smali&quot; is the name of the tool/format, don't translate it.</extracomment>
+      <translation>Smali リファレンスを更新中です...</translation>
     </message>
     <message>
-        <source>Updating directory structure...</source>
-        <translation>ディレクトリ構造を更新しています...</translation>
+      <source>Updating directory structure...</source>
+      <translation>ディレクトリ構造を更新中です...</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>BaseEditableSheet</name>
     <message>
-        <source>Save the changes?</source>
-        <translation>変更を保存しますか？</translation>
+      <source>Save the changes?</source>
+      <translation>変更を保存しますか？</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>保存</translation>
+      <source>&amp;Save</source>
+      <translation>保存(&amp;S)</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>BaseFileSheet</name>
     <message>
-        <source>&amp;Replace Resource...</source>
-        <translation>リソースを置換...</translation>
+      <source>&amp;Replace Resource...</source>
+      <translation>リソースを置換(&amp;R)...</translation>
     </message>
     <message>
-        <source>&amp;Save Resource</source>
-        <translation>リソースを保存</translation>
+      <source>&amp;Save Resource</source>
+      <translation>リソースを保存(&amp;S)</translation>
     </message>
     <message>
-        <source>Save Resource &amp;As...</source>
-        <translation>リソースに名前を付けて保存...</translation>
+      <source>Save Resource &amp;As...</source>
+      <translation>名前を付けてリソースを保存(&amp;A)</translation>
     </message>
     <message>
-        <source>&amp;Open Resource Directory</source>
-        <extracomment>This string refers to a single resource.</extracomment>
-        <translation>リソースディレクトリを開く</translation>
+      <source>&amp;Open Resource Directory</source>
+      <extracomment>This string refers to a single resource.</extracomment>
+      <translation>リソースのディレクトリを開く(&amp;O)</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>CodeSearchBar</name>
     <message>
-        <source>No results</source>
-        <translation>該当なし</translation>
+      <source>No results</source>
+      <translation>結果が見つかりませんでした</translation>
     </message>
     <message>
-        <source>Find:</source>
-        <translation>検索:</translation>
+      <source>Find:</source>
+      <translation>検索:</translation>
     </message>
     <message>
-        <source>Replace:</source>
-        <translation>置換:</translation>
+      <source>Replace:</source>
+      <translation>置換:</translation>
     </message>
     <message>
-        <source>Close</source>
-        <translation>閉じる</translation>
+      <source>Close</source>
+      <translation>閉じる</translation>
     </message>
     <message>
-        <source>Replace</source>
-        <translation>置換</translation>
+      <source>Replace</source>
+      <translation>置換</translation>
     </message>
     <message>
-        <source>Replace All</source>
-        <translation>すべて置換</translation>
+      <source>Replace All</source>
+      <translation>すべて置換</translation>
     </message>
     <message>
-        <source>Hide the Replace Bar</source>
-        <translation>置換バーの非表示</translation>
+      <source>Hide the Replace Bar</source>
+      <translation>置換バーを隠す</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>CodeSheet</name>
     <message>
-        <source>Would you like to download syntax definitions for this and other formats?</source>
-        <translation>このフォーマットや他のフォーマットのシンタックス定義をダウンロードしたいですか？</translation>
+      <source>Would you like to download syntax definitions for this and other formats?</source>
+      <translation>この形式および他の形式の構文定義をダウンロードしますか？</translation>
     </message>
     <message>
-        <source>Downloading syntax definitions...</source>
-        <translation>構文定義のダウンロード...</translation>
+      <source>Downloading syntax definitions...</source>
+      <translation>構文定義をダウンロード中です...</translation>
     </message>
     <message>
-        <source>Download Syntax Definitions</source>
-        <translation>構文定義のダウンロード</translation>
+      <source>Download Syntax Definitions</source>
+      <translation>構文定義をダウンロード</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>DeviceItemsModel</name>
     <message>
-        <source>Alias</source>
-        <translation>エイリアス</translation>
+      <source>Alias</source>
+      <translation>エイリアス</translation>
     </message>
     <message>
-        <source>Serial Number</source>
-        <translation>シリアル番号</translation>
+      <source>Serial Number</source>
+      <translation>シリアルナンバー</translation>
     </message>
     <message>
-        <source>Product</source>
-        <translation>製品</translation>
+      <source>Product</source>
+      <translation>プロダクト</translation>
     </message>
     <message>
-        <source>Model</source>
-        <translation>モデル</translation>
+      <source>Model</source>
+      <translation>モデル</translation>
     </message>
     <message>
-        <source>Device</source>
-        <translation>デバイス</translation>
+      <source>Device</source>
+      <translation>デバイス</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>DeviceManager</name>
     <message>
-        <source>Device Manager</source>
-        <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
-        <translation>デバイスマネージャー</translation>
+      <source>Device Manager</source>
+      <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
+      <translation>デバイスマネージャー</translation>
     </message>
     <message>
-        <source>Select a device:</source>
-        <translation>デバイスを選択:</translation>
+      <source>Select a device:</source>
+      <translation>デバイスを選択:</translation>
     </message>
     <message>
-        <source>Refresh</source>
-        <translation>リフレッシュ</translation>
+      <source>Refresh</source>
+      <translation>更新</translation>
     </message>
     <message>
-        <source>Custom name</source>
-        <translation>カスタム名</translation>
+      <source>Custom name</source>
+      <translation>名前を変更</translation>
     </message>
     <message>
-        <source>Device Information</source>
-        <translation>デバイス情報</translation>
+      <source>Device Information</source>
+      <translation>デバイス情報</translation>
     </message>
     <message>
-        <source>Could not fetch the device list.</source>
-        <translation>デバイスリストの取得に失敗しました。</translation>
+      <source>Could not fetch the device list.</source>
+      <translation>デバイスの一覧を取得できませんでした。</translation>
     </message>
     <message>
-        <source>Select Device</source>
-        <translation>デバイスの選択</translation>
+      <source>Select Device</source>
+      <translation>デバイスを選択</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Dialogs</name>
     <message>
-        <source>Install APK</source>
-        <translation>APKをインストール</translation>
+      <source>Install APK</source>
+      <translation>APK をインストール</translation>
     </message>
     <message>
-        <source>Install</source>
-        <translation>インストール</translation>
+      <source>Install</source>
+      <translation>インストール</translation>
     </message>
     <message>
-        <source>Screenshot</source>
-        <translation>スクリーンショット</translation>
+      <source>Screenshot</source>
+      <translation>スクリーンショット</translation>
     </message>
     <message>
-        <source>Copy to Clipboard</source>
-        <translation>クリップボードにコピー</translation>
+      <source>Copy to Clipboard</source>
+      <translation>クリップボードにコピー</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Downloader</name>
     <message>
-        <source>Downloading</source>
-        <translation>ダウンロード中</translation>
+      <source>Downloading</source>
+      <translation>ダウンロード中</translation>
     </message>
     <message>
-        <source>Downloading %1...</source>
-        <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
-        <translation>ダウンロード中 %1...</translation>
+      <source>Downloading %1...</source>
+      <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
+      <translation>%1 をダウンロード中...</translation>
     </message>
     <message>
-        <source>Could not save %1:</source>
-        <extracomment>&quot;%1&quot; will be replaced with a title of the saved file.</extracomment>
-        <translation>Could not save %1:</translation>
+      <source>Could not save %1:</source>
+      <extracomment>&quot;%1&quot; will be replaced with a title of the saved file.</extracomment>
+      <translation>%1 の保存ができません:</translation>
     </message>
     <message>
-        <source>Could not download %1:</source>
-        <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
-        <translation>ダウンロードできませんでした %1:</translation>
+      <source>Could not download %1:</source>
+      <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
+      <translation>%1 のダウンロードができません:</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>FileBox</name>
     <message>
-        <source>Reset</source>
-        <translation>リセット</translation>
+      <source>Reset</source>
+      <translation>リセット</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>FileFormatList</name>
     <message>
-        <source>All supported files</source>
-        <translation>サポートされているすべてのファイル</translation>
+      <source>All supported files</source>
+      <translation>すべての対応したファイル</translation>
     </message>
     <message>
-        <source>All files</source>
-        <translation>すべてのファイル</translation>
+      <source>All files</source>
+      <translation>すべてのファイル</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>FrameworkManager</name>
     <message>
-        <source>Framework Manager</source>
-        <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
-        <translation>Framework Manager</translation>
+      <source>Framework Manager</source>
+      <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
+      <translation>フレームワークマネージャー</translation>
     </message>
     <message>
-        <source>&amp;Install</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>&amp;Install</translation>
+      <source>&amp;Install</source>
+      <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+      <translation>インストール(&amp;I)</translation>
     </message>
     <message>
-        <source>Remove</source>
-        <translation>削除</translation>
+      <source>Remove</source>
+      <translation>削除</translation>
     </message>
     <message>
-        <source>Open Directory</source>
-        <translation>ディレクトリを開く</translation>
+      <source>Open Directory</source>
+      <translation>ディレクトリを開く</translation>
     </message>
     <message>
-        <source>Could not install the &quot;%1&quot; framework.</source>
-        <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
-        <translation>&quot;%1&quot; フレームワークをインストール出来ませんでした</translation>
+      <source>Could not install the &quot;%1&quot; framework.</source>
+      <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
+      <translation>「%1」のフレームワークをインストールできませんでした。</translation>
     </message>
     <message>
-        <source>Could not remove the &quot;%1&quot; framework.</source>
-        <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
-        <translation>&quot;%1&quot; フレームワークを削除できませんでした。.</translation>
+      <source>Could not remove the &quot;%1&quot; framework.</source>
+      <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
+      <translation>「%1」のフレームワークを削除できませんでした。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>IconItemsModel</name>
     <message>
-        <source>Round icon</source>
-        <translation>丸いアイコン</translation>
+      <source>Round icon</source>
+      <translation>丸みを帯びたアイコン</translation>
     </message>
     <message>
-        <source>TV banner</source>
-        <translation>テレビ バナー</translation>
+      <source>TV banner</source>
+      <translation>TV バナー</translation>
     </message>
     <message>
-        <source>Application</source>
-        <translation>アプリケーション</translation>
+      <source>Application</source>
+      <translation>アプリ</translation>
     </message>
     <message>
-        <source>Activities</source>
-        <extracomment>This string refers to the Android activities (https://developer.android.com/guide/components/activities).</extracomment>
-        <translation>アクティビティ</translation>
+      <source>Activities</source>
+      <extracomment>This string refers to the Android activities (https://developer.android.com/guide/components/activities).</extracomment>
+      <translation>アクティビティ</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ImageSheet</name>
     <message>
-        <source>Size</source>
-        <translation>サイズ</translation>
+      <source>Size</source>
+      <translation>サイズ</translation>
     </message>
     <message>
-        <source>Zoom</source>
-        <translation>拡大</translation>
+      <source>Zoom</source>
+      <translation>拡大</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>KeyCreator</name>
     <message>
-        <source>Create Key</source>
-        <translation>キーの作成</translation>
+      <source>Create Key</source>
+      <translation>キーを作成</translation>
     </message>
     <message>
-        <source>Alias</source>
-        <translation>エイリアス</translation>
+      <source>Alias</source>
+      <translation>エイリアス</translation>
     </message>
     <message>
-        <source>Key Password</source>
-        <translation>キーパスワード</translation>
+      <source>Key Password</source>
+      <translation>キーのパスワード</translation>
     </message>
     <message>
-        <source>Confirm Password</source>
-        <translation>パスワードを認証</translation>
+      <source>Confirm Password</source>
+      <translation>パスワードを確認</translation>
     </message>
     <message>
-        <source>First and Last Name</source>
-        <translation>名前と苗字</translation>
+      <source>First and Last Name</source>
+      <translation>名と姓</translation>
     </message>
     <message>
-        <source>Organizational Unit</source>
-        <translation>組織 単位</translation>
+      <source>Organizational Unit</source>
+      <translation>組織単位</translation>
     </message>
     <message>
-        <source>Organization</source>
-        <translation>会社</translation>
+      <source>Organization</source>
+      <translation>組織</translation>
     </message>
     <message>
-        <source>City or Locality</source>
-        <translation>都市または地域</translation>
+      <source>City or Locality</source>
+      <translation>都市または地域</translation>
     </message>
     <message>
-        <source>State or Province</source>
-        <translation>州または県</translation>
+      <source>State or Province</source>
+      <translation>州または県</translation>
     </message>
     <message>
-        <source>Country Code</source>
-        <translation>国コード</translation>
+      <source>Country Code</source>
+      <translation>国コード</translation>
     </message>
     <message>
-        <source>Password</source>
-        <translation>パスワード</translation>
+      <source>Password</source>
+      <translation>パスワード</translation>
     </message>
     <message>
-        <source>Validity (Years)</source>
-        <translation>有効期間（年）</translation>
+      <source>Validity (Years)</source>
+      <translation>有効期限 (年)</translation>
     </message>
     <message>
-        <source>Key</source>
-        <translation>キー</translation>
+      <source>Key</source>
+      <translation>キー</translation>
     </message>
     <message>
-        <source>Key has been successfully created!</source>
-        <translation>キーが正常に作成されました!</translation>
+      <source>Key has been successfully created!</source>
+      <translation>キーが正常に作成されました！</translation>
     </message>
     <message>
-        <source>Password must be at least 6 characters.</source>
-        <translation>パスワードは少なくとも6文字以上でなければなりません。</translation>
+      <source>Password must be at least 6 characters.</source>
+      <translation>パスワードは 6 文字以上でなければなりません。</translation>
     </message>
     <message>
-        <source>Passwords do not match.</source>
-        <translation>パスワードが一致していません。</translation>
+      <source>Passwords do not match.</source>
+      <translation>パスワードが一致しません。</translation>
     </message>
     <message>
-        <source>Please fill out the required fields.</source>
-        <translation>必須フィールドに入力してください。</translation>
+      <source>Please fill out the required fields.</source>
+      <translation>必須項目を入力してください。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>KeyManager</name>
     <message>
-        <source>Key Manager</source>
-        <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
-        <translation>キーマネージャー</translation>
+      <source>Key Manager</source>
+      <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
+      <translation>キーマネージャー</translation>
     </message>
     <message>
-        <source>Custom Keystore</source>
-        <translation>カスタムキーストア</translation>
+      <source>Custom Keystore</source>
+      <translation>カスタムキーストア</translation>
     </message>
     <message>
-        <source>Create</source>
-        <translation>作成する</translation>
+      <source>Create</source>
+      <translation>作成</translation>
     </message>
     <message>
-        <source>Keystore path:</source>
-        <translation>キーストアのパス:</translation>
+      <source>Keystore path:</source>
+      <translation>キーストアのパス:</translation>
     </message>
     <message>
-        <source>Keystore password:</source>
-        <translation>キーストアのパスワード:</translation>
+      <source>Keystore password:</source>
+      <translation>キーストアのパスワード:</translation>
     </message>
     <message>
-        <source>Key alias:</source>
-        <translation>キーエイリアス:</translation>
+      <source>Key alias:</source>
+      <translation>キーのエイリアス:</translation>
     </message>
     <message>
-        <source>Key password:</source>
-        <translation>キーパスワード:</translation>
+      <source>Key password:</source>
+      <translation>キーのパスワード:</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>KeySelector</name>
     <message>
-        <source>Select Key</source>
-        <translation>キーを選択</translation>
+      <source>Select Key</source>
+      <translation>キーを選択</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Keystore</name>
     <message>
-        <source>Enter the keystore password:</source>
-        <translation>キーストアのパスワードを入力します:</translation>
+      <source>Enter the keystore password:</source>
+      <translation>キーストアのパスワードを入力:</translation>
     </message>
     <message>
-        <source>Enter the key password:</source>
-        <translation>キーパスワードを入力します:</translation>
+      <source>Enter the key password:</source>
+      <translation>キーのパスワードを入力:</translation>
     </message>
     <message>
-        <source>You are using the built-in keystore provided for demonstrational purposes. It can be practical for testing or personal usage. However, if you plan to distribute this APK, we recommend you to specify/create your own keystore via Key Manager.</source>
-        <translation>あなたは、デモ目的で提供される組み込みのキーストアを使用しています。テストや個人的な使用には実用的です。しかし、このAPKを配布する予定がある場合、キーマネージャを介して独自のキーストアを指定/作成することをお勧めします。</translation>
+      <source>You are using the built-in keystore provided for demonstrational purposes. It can be practical for testing or personal usage. However, if you plan to distribute this APK, we recommend you to specify/create your own keystore via Key Manager.</source>
+      <translation>デモ用に提供されている内蔵のキーストアを使用中です。テストや個人使用であれば実用的です。ただし、この APK を配布する予定がある場合は、キーマネージャーを使用して独自のキーストアを指定または作成することをお勧めします。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>KeystoreCreator</name>
     <message>
-        <source>Create Keystore</source>
-        <translation>Keystore作成</translation>
+      <source>Create Keystore</source>
+      <translation>キーストアを作成</translation>
     </message>
     <message>
-        <source>Keystore Password</source>
-        <translation>キーストアのパスワード</translation>
+      <source>Keystore Password</source>
+      <translation>キーストアのパスワード</translation>
     </message>
     <message>
-        <source>Keystore has been successfully created!</source>
-        <translation>キーストアが正常に作成されました!</translation>
+      <source>Keystore has been successfully created!</source>
+      <translation>キーストアが正常に作成されました！</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Keytool::Aliases</name>
     <message>
-        <source>Could not read keystore: incorrect password.</source>
-        <translation>キーストアを読み取れませんでした:パスワードが正しくありません。</translation>
+      <source>Could not read keystore: incorrect password.</source>
+      <translation>キーストアを読み取れません: パスワードが正しくありません。</translation>
     </message>
     <message>
-        <source>Could not read keystore. See details for more information.</source>
-        <translation>キーストアを読み取れませんでした。詳細を参照してください。</translation>
+      <source>Could not read keystore. See details for more information.</source>
+      <translation>キーストアを読み取れませんでした。詳細については情報を参照してください。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Keytool::Genkey</name>
     <message>
-        <source>Could not write to keystore: alias already exists.</source>
-        <translation>キーストアに書き込めませんでした:既に存在するエイリアスがあります。</translation>
+      <source>Could not write to keystore: alias already exists.</source>
+      <translation>キーストアに書き込めません: エイリアスが既に存在します。</translation>
     </message>
     <message>
-        <source>Could not write to keystore. See details for more information.</source>
-        <translation>キーストアに書き込めませんでした。詳細 を参照してください。</translation>
+      <source>Could not write to keystore. See details for more information.</source>
+      <translation>キーストアに書き込めませんでした。詳細については情報を参照してください。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>LogView</name>
     <message>
-        <source>Log</source>
-        <extracomment>&quot;Log&quot; as in event log, message log, etc.</extracomment>
-        <translation>ログ</translation>
+      <source>Log</source>
+      <extracomment>&quot;Log&quot; as in event log, message log, etc.</extracomment>
+      <translation>ログ</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>MainWindow</name>
     <message>
-        <source>&amp;File</source>
-        <extracomment>Refers to a menu bar (along with Edit, View, Window, Help, and similar items).</extracomment>
-        <translation>&amp;ファイル</translation>
+      <source>&amp;File</source>
+      <extracomment>Refers to a menu bar (along with Edit, View, Window, Help, and similar items).</extracomment>
+      <translation>ファイル(&amp;F)</translation>
     </message>
     <message>
-        <source>&amp;Tools</source>
-        <extracomment>Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
-        <translation>&amp;ツール</translation>
+      <source>&amp;Tools</source>
+      <extracomment>Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
+      <translation>ツール(&amp;T)</translation>
     </message>
     <message>
-        <source>&amp;Settings</source>
-        <extracomment>Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
-        <translation>&amp;設定</translation>
+      <source>&amp;Settings</source>
+      <extracomment>Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
+      <translation>設定(&amp;S)</translation>
     </message>
     <message>
-        <source>&amp;Window</source>
-        <extracomment>Refers to a menu bar (along with File, Edit, View, Help, and similar items).</extracomment>
-        <translation>&amp;ウインドウ</translation>
+      <source>&amp;Window</source>
+      <extracomment>Refers to a menu bar (along with File, Edit, View, Help, and similar items).</extracomment>
+      <translation>ウィンドウ(&amp;W)</translation>
     </message>
     <message>
-        <source>Tools</source>
-        <translation>ツール</translation>
+      <source>Tools</source>
+      <translation>ツール</translation>
     </message>
     <message>
-        <source>Remove Temporary Files...</source>
-        <translation>一時ファイルを削除...</translation>
+      <source>Remove Temporary Files...</source>
+      <translation>一時ファイルを削除...</translation>
     </message>
     <message>
-        <source>Projects</source>
-        <translation>プロジェクト</translation>
+      <source>Projects</source>
+      <translation>プロジェクト</translation>
     </message>
     <message>
-        <source>Resources</source>
-        <translation>リソース</translation>
+      <source>Resources</source>
+      <translation>リソース</translation>
     </message>
     <message>
-        <source>File System</source>
-        <translation>ファイルシステム</translation>
+      <source>File System</source>
+      <translation>ファイルシステム</translation>
     </message>
     <message>
-        <source>Manifest</source>
-        <translation>マニフェスト</translation>
+      <source>Manifest</source>
+      <translation>マニフェスト</translation>
     </message>
     <message>
-        <source>Icons</source>
-        <translation>アイコン</translation>
+      <source>Icons</source>
+      <translation>アイコン</translation>
     </message>
     <message>
-        <source>Filter</source>
-        <translation>フィルター</translation>
+      <source>Filter</source>
+      <translation>フィルター</translation>
     </message>
     <message>
-        <source>&amp;Help</source>
-        <extracomment>Refers to a menu bar (along with File, Edit, View, Window, and similar items).</extracomment>
-        <translation>&amp;ヘルプ</translation>
+      <source>&amp;Help</source>
+      <extracomment>Refers to a menu bar (along with File, Edit, View, Window, and similar items).</extracomment>
+      <translation>ヘルプ(&amp;H)</translation>
     </message>
     <message>
-        <source>Open &amp;Recent</source>
-        <translation>開く最近</translation>
+      <source>Open &amp;Recent</source>
+      <translation>最近開いたファイルを開く(&amp;R)</translation>
     </message>
     <message>
-        <source>&amp;Clear List</source>
-        <translation>クリア リスト</translation>
+      <source>&amp;Clear List</source>
+      <translation>一覧を消去(&amp;C)</translation>
     </message>
     <message>
-        <source>No Recent Files</source>
-        <translation>最近のファイルはありません</translation>
+      <source>No Recent Files</source>
+      <translation>最近開いたファイルはありません</translation>
     </message>
     <message>
-        <source>Open &amp;New Window</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>開く・新規ウィンドウ</translation>
+      <source>Open &amp;New Window</source>
+      <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+      <translation>新しいウィンドウを開く(&amp;N)</translation>
     </message>
     <message>
-        <source>&amp;About APK Editor Studio...</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; part.</extracomment>
-        <translation>&amp;APK Editor Studioについて</translation>
+      <source>&amp;About APK Editor Studio...</source>
+      <extracomment>Don't translate the &quot;APK Editor Studio&quot; part.</extracomment>
+      <translation>APK Editor Studio について(&amp;A)...</translation>
     </message>
     <message>
-        <source>About &amp;Qt...</source>
-        <extracomment>Don't translate the &quot;&amp;Qt&quot; part.</extracomment>
-        <translation>&amp;Qtについて</translation>
+      <source>About &amp;Qt...</source>
+      <extracomment>Don't translate the &quot;&amp;Qt&quot; part.</extracomment>
+      <translation>Qt について(&amp;Q)...</translation>
     </message>
     <message>
-        <source>Welcome</source>
-        <translation>ようこそ</translation>
+      <source>Welcome</source>
+      <translation>ようこそ</translation>
     </message>
     <message>
-        <source>This APK is already open:
+      <source>This APK is already open:
 %1
 Do you want to reopen it and lose any unsaved changes?</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to an APK.</extracomment>
-        <translation>このAPKは既に開いています:
+      <extracomment>&quot;%1&quot; will be replaced with a path to an APK.</extracomment>
+      <translation>この APK を既に開いています:
 %1
-再度開きますか? 保存されていない変更は失います.</translation>
+再度開いて保存されていない変更をすべて破棄してもよろしいですか？</translation>
     </message>
     <message>
-        <source>You have unsaved changes.
+      <source>You have unsaved changes.
 Do you want to discard them and exit?</source>
-        <translation>未保存の変更があります。
-それらを保存せずに終了しますか？</translation>
+      <translation>保存されていない変更があります。
+破棄して終了しますか？</translation>
     </message>
     <message>
-        <source>%1 not found. Restore the default path?</source>
-        <extracomment>&quot;%1&quot; will be replaced with a tool name.</extracomment>
-        <translation>%1 が見つかりません。 デフォルトのパスを復元しますか?</translation>
+      <source>%1 not found. Restore the default path?</source>
+      <extracomment>&quot;%1&quot; will be replaced with a tool name.</extracomment>
+      <translation>「%1」が見つかりません。既定のパスを復元しますか？</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ManifestModel</name>
     <message>
-        <source>Application Title</source>
-        <translation>アプリケーションタイトル</translation>
+      <source>Application Title</source>
+      <translation>アプリのタイトル</translation>
     </message>
     <message>
-        <source>Version Code</source>
-        <translation>バージョンコード</translation>
+      <source>Version Code</source>
+      <translation>バージョンコード</translation>
     </message>
     <message>
-        <source>Version Name</source>
-        <translation>バージョン名</translation>
+      <source>Version Name</source>
+      <translation>バージョン名</translation>
     </message>
     <message>
-        <source>Minimum SDK</source>
-        <translation>Minimum SDK</translation>
+      <source>Minimum SDK</source>
+      <translation>最小 SDK</translation>
     </message>
     <message>
-        <source>Target SDK</source>
-        <translation>Target SDK</translation>
+      <source>Target SDK</source>
+      <translation>ターゲット SDK</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>OptionsDialog</name>
     <message>
-        <source>Could not register file association.</source>
-        <translation>ファイルの関連付けに失敗しました。</translation>
+      <source>Could not register file association.</source>
+      <translation>ファイルの関連付けを登録できませんでした。</translation>
     </message>
     <message>
-        <source>Options</source>
-        <translation>オプション</translation>
+      <source>Options</source>
+      <translation>オプション</translation>
     </message>
     <message>
-        <source>Single-window mode</source>
-        <translation>シングルウィンドウモード</translation>
+      <source>Single-window mode</source>
+      <translation>シングルウィンドウモード</translation>
     </message>
     <message>
-        <source>Open .apk files in an existing window</source>
-        <extracomment>Don't translate the &quot;.apk&quot; part.</extracomment>
-        <translation>.apkファイルを既存のウィンドウで開く</translation>
+      <source>Open .apk files in an existing window</source>
+      <extracomment>Don't translate the &quot;.apk&quot; part.</extracomment>
+      <translation>既存のウィンドウで .apk を開く</translation>
     </message>
     <message>
-        <source>Check for updates automatically</source>
-        <translation>更新を自動で確認する</translation>
+      <source>Check for updates automatically</source>
+      <translation>更新を自動的に確認する</translation>
     </message>
     <message>
-        <source>Maximum recent files:</source>
-        <translation>最近のファイルの最大値です：</translation>
+      <source>Maximum recent files:</source>
+      <translation>最近開いたファイルの最大数:</translation>
     </message>
     <message>
-        <source>Use APK Editor Studio for .apk files</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
-        <translation>.apkファイルにはAPK Editor Studioを使用します。</translation>
+      <source>Use APK Editor Studio for .apk files</source>
+      <extracomment>Don't translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
+      <translation>.apk ファイルで APK Editor Studio を使用する</translation>
     </message>
     <message>
-        <source>Use APK Editor Studio to open .apk files</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
-        <translation>.apk ファイルを開くには APK Editor Studio を使用します。</translation>
+      <source>Use APK Editor Studio to open .apk files</source>
+      <extracomment>Don't translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
+      <translation>APK Editor Studio を使用して .apk ファイルを開く</translation>
     </message>
     <message>
-        <source>Add %1 action to Windows Explorer context menu</source>
-        <extracomment>&quot;%1&quot; will be replaced with an action name (e.g., Install, Optimize, Sign, etc.).</extracomment>
-        <translation>Add %1 action to Windows Explorer context menu</translation>
+      <source>Add %1 action to Windows Explorer context menu</source>
+      <extracomment>&quot;%1&quot; will be replaced with an action name (e.g., Install, Optimize, Sign, etc.).</extracomment>
+      <translation>Windows エクスプローラーのコンテキストメニューに「%1」のアクションを追加</translation>
     </message>
     <message>
-        <source>Install</source>
-        <translation>インストール</translation>
+      <source>Install</source>
+      <translation>インストール</translation>
     </message>
     <message>
-        <source>Optimize</source>
-        <translation>Optimize</translation>
+      <source>Optimize</source>
+      <translation>最適化</translation>
     </message>
     <message>
-        <source>Sign</source>
-        <extracomment>This is a verb.</extracomment>
-        <translation>署名</translation>
+      <source>Sign</source>
+      <extracomment>This is a verb.</extracomment>
+      <translation>署名</translation>
     </message>
     <message>
-        <source>Language:</source>
-        <translation>言語:</translation>
+      <source>Language:</source>
+      <translation>言語:</translation>
     </message>
     <message>
-        <source>Theme:</source>
-        <translation>テーマ:</translation>
+      <source>Theme:</source>
+      <translation>テーマ:</translation>
     </message>
     <message>
-        <source>Extracted from environment variables by default</source>
-        <translation>デフォルトで環境変数から抽出</translation>
+      <source>Extracted from environment variables by default</source>
+      <translation>既定で環境変数から抽出されます</translation>
     </message>
     <message>
-        <source>MB</source>
-        <extracomment>Megabytes</extracomment>
-        <translation>MB</translation>
+      <source>MB</source>
+      <extracomment>Megabytes</extracomment>
+      <translation>MB</translation>
     </message>
     <message>
-        <source>Default</source>
-        <translation>デフォルト</translation>
+      <source>Default</source>
+      <translation>既定</translation>
     </message>
     <message>
-        <source>Java path:</source>
-        <translation>Java path:</translation>
+      <source>Java path:</source>
+      <translation>Java のパス:</translation>
     </message>
     <message>
-        <source>Initial heap size:</source>
-        <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
-        <translation type="unfinished"/>
+      <source>Initial heap size:</source>
+      <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
+      <translation>初期のヒープサイズ:</translation>
     </message>
     <message>
-        <source>Maximum heap size:</source>
-        <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
-        <translation type="unfinished"/>
+      <source>Maximum heap size:</source>
+      <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
+      <translation>最大のヒープサイズ:</translation>
     </message>
     <message>
-        <source>Apktool path:</source>
-        <extracomment>&quot;Apktool&quot; is the name of the tool, don't translate it.</extracomment>
-        <translation>Apktool path:</translation>
+      <source>Apktool path:</source>
+      <extracomment>&quot;Apktool&quot; is the name of the tool, don't translate it.</extracomment>
+      <translation>Apktool のパス:</translation>
     </message>
     <message>
-        <source>Extraction path:</source>
-        <translation>抽出パス:</translation>
+      <source>Extraction path:</source>
+      <translation>展開先のパス:</translation>
     </message>
     <message>
-        <source>Frameworks path:</source>
-        <translation>Frameworks path:</translation>
+      <source>Frameworks path:</source>
+      <translation>フレームワークのパス:</translation>
     </message>
     <message>
-        <source>Unpacking</source>
-        <translation>解凍</translation>
+      <source>Unpacking</source>
+      <translation>アンパック中</translation>
     </message>
     <message>
-        <source>Decompile source code (smali)</source>
-        <extracomment>&quot;Smali&quot; is the name of the tool/format, don't translate it.</extracomment>
-        <translation>ソースコードの逆コンパイル（smali）</translation>
+      <source>Decompile source code (smali)</source>
+      <extracomment>&quot;Smali&quot; is the name of the tool/format, don't translate it.</extracomment>
+      <translation>ソースコードをデコンパイル (smali)</translation>
     </message>
     <message>
-        <source>Decompile broken resources</source>
-        <translation>壊れたリソースを逆コンパイルする</translation>
+      <source>Decompile broken resources</source>
+      <translation>壊れたリソースをデコンパイル</translation>
     </message>
     <message>
-        <source>Packing</source>
-        <translation type="unfinished"/>
+      <source>Packing</source>
+      <translation>パック中</translation>
     </message>
     <message>
-        <source>Use AAPT2</source>
-        <extracomment>&quot;AAPT2&quot; is the name of the tool, don't translate it.</extracomment>
-        <translation type="unfinished"/>
+      <source>Use AAPT2</source>
+      <extracomment>&quot;AAPT2&quot; is the name of the tool, don't translate it.</extracomment>
+      <translation>AAPT2 を使用</translation>
     </message>
     <message>
-        <source>Pack for debugging</source>
-        <translation>デバッグ用パック</translation>
+      <source>Pack for debugging</source>
+      <translation>デバッグ用にパック</translation>
     </message>
     <message>
-        <source>Sign APK after packing</source>
-        <translation>パッキング後に APK に署名する</translation>
+      <source>Sign APK after packing</source>
+      <translation>パッキング後に APK に署名</translation>
     </message>
     <message>
-        <source>Open Key Manager</source>
-        <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
-        <translation>キーマネージャーを開く</translation>
+      <source>Open Key Manager</source>
+      <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
+      <translation>キーマネージャーを開く</translation>
     </message>
     <message>
-        <source>Apksigner path:</source>
-        <extracomment>&quot;Apksigner&quot; is the name of the tool, don't translate it.</extracomment>
-        <translation>Apksigner path:</translation>
+      <source>Apksigner path:</source>
+      <extracomment>&quot;Apksigner&quot; is the name of the tool, don't translate it.</extracomment>
+      <translation>Apksigner のパス:</translation>
     </message>
     <message>
-        <source>Optimize APK after packing</source>
-        <translation>パッキング後のAPKを最適化する</translation>
+      <source>Optimize APK after packing</source>
+      <translation>パッキング後に APK を最適化</translation>
     </message>
     <message>
-        <source>Zipalign path:</source>
-        <extracomment>&quot;Zipalign&quot; is the name of the tool, don't translate it.</extracomment>
-        <translation>ジパリパスのことです:</translation>
+      <source>Zipalign path:</source>
+      <extracomment>&quot;Zipalign&quot; is the name of the tool, don't translate it.</extracomment>
+      <translation>Zipalign のパス:</translation>
     </message>
     <message>
-        <source>Open Device Manager</source>
-        <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
-        <translation>デバイスマネージャーを開く</translation>
+      <source>Open Device Manager</source>
+      <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
+      <translation>デバイスマネージャーを開く</translation>
     </message>
     <message>
-        <source>ADB path:</source>
-        <extracomment>&quot;ADB&quot; is the name of the tool, don't translate it.</extracomment>
-        <translation>ADB path:</translation>
+      <source>ADB path:</source>
+      <extracomment>&quot;ADB&quot; is the name of the tool, don't translate it.</extracomment>
+      <translation>ADB のパス:</translation>
     </message>
     <message>
-        <source>General</source>
-        <translation>一般</translation>
+      <source>General</source>
+      <translation>一般</translation>
     </message>
     <message>
-        <source>Appearance</source>
-        <translation type="unfinished"/>
+      <source>Appearance</source>
+      <translation>外観</translation>
     </message>
     <message>
-        <source>The changes will take effect after the application restart.</source>
-        <translation>変更は、アプリケーションを再起動した後に有効になります。</translation>
+      <source>The changes will take effect after the application restart.</source>
+      <translation>変更はアプリの再起動後に有効化されます。</translation>
     </message>
     <message>
-        <source>Open Framework Manager</source>
-        <translation>Framework Managerを開く</translation>
+      <source>Open Framework Manager</source>
+      <translation>フレームワークマネージャーを開く</translation>
     </message>
     <message>
-        <source>Decompile only main classes</source>
-        <translation>メインクラスのみデコンパイル</translation>
+      <source>Decompile only main classes</source>
+      <translation>メインクラスのみデコンパイル</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Package</name>
     <message>
-        <source>Done.</source>
-        <translation>終了</translation>
+      <source>Done.</source>
+      <translation>完了しました。</translation>
     </message>
     <message>
-        <source>Error unpacking APK.</source>
-        <translation>APKの解凍中にエラーが発生しました。</translation>
+      <source>Error unpacking APK.</source>
+      <translation>APK のアンパックに失敗しました。</translation>
     </message>
     <message>
-        <source>Unpacking APK...</source>
-        <translation>APKを展開しています...</translation>
+      <source>Unpacking APK...</source>
+      <translation>APK をアンパック中です...</translation>
     </message>
     <message>
-        <source>Packing APK...</source>
-        <translation>Packing APK...</translation>
+      <source>Packing APK...</source>
+      <translation>APK をパッキング中です...</translation>
     </message>
     <message>
-        <source>Error packing APK.</source>
-        <translation>APKのパッキングに失敗した。</translation>
+      <source>Error packing APK.</source>
+      <translation>APK のパッキングに失敗しました。</translation>
     </message>
     <message>
-        <source>Optimizing APK...</source>
-        <translation>APKの最適化...</translation>
+      <source>Optimizing APK...</source>
+      <translation>APK を最適化中です...</translation>
     </message>
     <message>
-        <source>Error optimizing APK.</source>
-        <translation>APKの最適化エラー。</translation>
+      <source>Error optimizing APK.</source>
+      <translation>APK の最適化に失敗しました。</translation>
     </message>
     <message>
-        <source>Signing APK...</source>
-        <translation>APKに署名しています...</translation>
+      <source>Signing APK...</source>
+      <translation>APK を署名中です...</translation>
     </message>
     <message>
-        <source>Error signing APK.</source>
-        <translation>APKへの署名エラー。</translation>
+      <source>Error signing APK.</source>
+      <translation>APK の署名に失敗しました。</translation>
     </message>
     <message>
-        <source>Installing APK...</source>
-        <translation>APKをインストールしています...</translation>
+      <source>Installing APK...</source>
+      <translation>APK をインストール中です...</translation>
     </message>
     <message>
-        <source>Error installing APK.</source>
-        <translation>APKのインストール中にエラーが発生しました。</translation>
+      <source>Error installing APK.</source>
+      <translation>APK のインストール失敗しました。</translation>
     </message>
     <message>
-        <source>Reading APK contents...</source>
-        <translation>APKコンテンツを読み込んでいます...</translation>
+      <source>Reading APK contents...</source>
+      <translation>APK のコンテンツを読み取り中です...</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>PermissionEditor</name>
     <message>
-        <source>Permission Editor</source>
-        <extracomment>This string refers to multiple permissions (as in &quot;Editor of permissions&quot;).</extracomment>
-        <translation>Permission エディタ</translation>
+      <source>Permission Editor</source>
+      <extracomment>This string refers to multiple permissions (as in &quot;Editor of permissions&quot;).</extracomment>
+      <translation>権限の編集</translation>
     </message>
     <message>
-        <source>Add</source>
-        <translation>追加</translation>
+      <source>Add</source>
+      <translation>追加</translation>
     </message>
     <message>
-        <source>Documentation</source>
-        <translation>ドキュメンテーション</translation>
+      <source>Documentation</source>
+      <translation>ドキュメント</translation>
     </message>
     <message>
-        <source>Remove</source>
-        <translation>削除</translation>
+      <source>Remove</source>
+      <translation>削除</translation>
     </message>
     <message>
-        <source>Are you sure you want to remove the %1 permission?</source>
-        <extracomment>%1 will be replaced with a programmatic Android permission name (e.g., &quot;android.permission.SEND_SMS&quot;, &quot;android.permission.CAMERA&quot;, etc.).</extracomment>
-        <translation>%1権限を削除してもよろしいですか？</translation>
+      <source>Are you sure you want to remove the %1 permission?</source>
+      <extracomment>%1 will be replaced with a programmatic Android permission name (e.g., &quot;android.permission.SEND_SMS&quot;, &quot;android.permission.CAMERA&quot;, etc.).</extracomment>
+      <translation>%1 の権限を削除してもよろしいですか？</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Project</name>
     <message>
-        <source>Package renaming is an experimental function which, in its current state, may lead to crashes and data loss. You can join the discussion and help us improve this feature &lt;a href=&quot;%1&quot;&gt;here&lt;/a&gt;.</source>
-        <translation>パッケージのリネームは実験的な機能であり、現状ではクラッシュやデータ消失につながる可能性があります。ディスカッションに参加し、この機能の改善にご協力ください &lt;a href=&quot;%1&quot;&gt;here&lt;/a&gt;.</translation>
+      <source>Package renaming is an experimental function which, in its current state, may lead to crashes and data loss. You can join the discussion and help us improve this feature &lt;a href=&quot;%1&quot;&gt;here&lt;/a&gt;.</source>
+      <translation>パッケージ名の変更は実験的な機能であり、現状ではクラッシュやデータの損失に繋がる可能性があります。&lt;a href=&quot;%1&quot;&gt;こちら&lt;/a&gt;でディスカッションに参加して、この機能の改善にご協力ください。</translation>
     </message>
     <message>
-        <source>Cloning the APK requires the source code decompilation to be turned on. Proceed?</source>
-        <translation>APKのクローンを作成するには、ソースコードの逆コンパイルがオンになっている必要があります。進める？</translation>
+      <source>Cloning the APK requires the source code decompilation to be turned on. Proceed?</source>
+      <translation>APK をクローンするには、ソースコードの逆コンパイルをオンにする必要があります。続行しますか？</translation>
     </message>
     <message>
-        <source>Settings have been applied. Please, reopen this APK.</source>
-        <translation>設定が適用されました。このAPKを再度開いてください。</translation>
+      <source>Settings have been applied. Please, reopen this APK.</source>
+      <translation>設定が適用されました。この APK を再度開いてください。</translation>
     </message>
     <message>
-        <source>Please, reopen this APK in order to unpack the source code and clone the APK.</source>
-        <translation>このAPKを再度開いて、ソースコードを解凍し、APKをクローンしてください。</translation>
+      <source>Please, reopen this APK in order to unpack the source code and clone the APK.</source>
+      <translation>ソースコードをアンパックして APK をクローンするには、この APK を 再度開いてください。</translation>
     </message>
     <message>
-        <source>Package Name:</source>
-        <translation>パッケージ名:</translation>
+      <source>Package Name:</source>
+      <translation>パッケージ名:</translation>
     </message>
     <message>
-        <source>Could not clone the APK.</source>
-        <translation>APKのクローンを作成できませんでした。</translation>
+      <source>Could not clone the APK.</source>
+      <translation>APK のクローンに失敗しました。</translation>
     </message>
     <message>
-        <source>APK has been successfully cloned!</source>
-        <translation>APKのクローニングに成功しました！</translation>
+      <source>APK has been successfully cloned!</source>
+      <translation>APK のクローンが正常に作成されました！</translation>
     </message>
     <message>
-        <source>Do you want to save changes before packing?</source>
-        <translation>梱包する前に変更を保存しますか?</translation>
+      <source>Do you want to save changes before packing?</source>
+      <translation>パッキングをする前に変更を保存しますか？</translation>
     </message>
     <message>
-        <source>Do you want to save changes and pack the APK before installing?</source>
-        <translation>インストールする前に変更を保存してAPKをpackしますか？</translation>
+      <source>Do you want to save changes and pack the APK before installing?</source>
+      <translation>インストールする前に変更を保存して APK をパックしますか？</translation>
     </message>
     <message>
-        <source>The format is not supported.</source>
-        <translation>このフォーマットはサポートされていません。</translation>
+      <source>The format is not supported.</source>
+      <translation>この形式には対応していません。</translation>
     </message>
     <message>
-        <source>Cloning APK</source>
-        <translation>クローン作成 APK</translation>
+      <source>Cloning APK</source>
+      <translation>APK をクローン中です</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ProjectManager</name>
     <message>
-        <source>Are you sure you want to close this APK?
+      <source>Are you sure you want to close this APK?
 Any unsaved changes will be lost.</source>
-        <translation>このAPKを閉じてもよろしいですか?
-未保存の変更は失われます。</translation>
+      <translation>この APK を閉じてもよろしいですか？
+保存していない変更は失われます。</translation>
     </message>
     <message>
-        <source>&amp;Save APK...</source>
-        <translation>APKを保存...</translation>
+      <source>&amp;Save APK...</source>
+      <translation>APK を保存(&amp;S)...</translation>
     </message>
     <message>
-        <source>&amp;Install APK...</source>
-        <translation>APKをインストール...</translation>
+      <source>&amp;Install APK...</source>
+      <translation>APK をインストール(&amp;I)...</translation>
     </message>
     <message>
-        <source>O&amp;pen Contents</source>
-        <extracomment>Displayed as &quot;Open Contents&quot;.</extracomment>
-        <translation>を開くコンテンツ</translation>
+      <source>O&amp;pen Contents</source>
+      <extracomment>Displayed as &quot;Open Contents&quot;.</extracomment>
+      <translation>コンテンツを開く(&amp;P)</translation>
     </message>
     <message>
-        <source>&amp;Close APK</source>
-        <translation>APKを閉じる</translation>
+      <source>&amp;Close APK</source>
+      <translation>APK を閉じる(&amp;C)</translation>
     </message>
     <message>
-        <source>&amp;Project Manager</source>
-        <extracomment>This string refers to a single project (as in &quot;Manager of a project&quot;).</extracomment>
-        <translation>&amp;プロジェクトマネージャー</translation>
+      <source>&amp;Project Manager</source>
+      <extracomment>This string refers to a single project (as in &quot;Manager of a project&quot;).</extracomment>
+      <translation>プロジェクトマネージャー(&amp;P)</translation>
     </message>
     <message>
-        <source>Edit Application &amp;Title</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>アプリケーション タイトルを編集</translation>
+      <source>Edit Application &amp;Title</source>
+      <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+      <translation>アプリのタイトルを編集(&amp;T)</translation>
     </message>
     <message>
-        <source>Edit Application &amp;Permissions</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>アプリケーションと権限を編集</translation>
+      <source>Edit Application &amp;Permissions</source>
+      <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+      <translation>アプリの権限を編集(&amp;P)</translation>
     </message>
     <message>
-        <source>&amp;Clone APK</source>
-        <translation type="unfinished"/>
+      <source>&amp;Clone APK</source>
+      <translation>APK をクローン(&amp;C)</translation>
     </message>
     <message>
-        <source>View &amp;Signatures</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation type="unfinished"/>
+      <source>View &amp;Signatures</source>
+      <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+      <translation>署名を表示(&amp;S)</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>保存</translation>
+      <source>&amp;Save</source>
+      <translation>保存(&amp;S)</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>名前を付けて保存...</translation>
+      <source>Save &amp;As...</source>
+      <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+      <translation>名前を付けて保存(&amp;A)...</translation>
     </message>
     <message>
-        <source>Ta&amp;b</source>
-        <extracomment>Displayed as &quot;Tab&quot;. Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
-        <translation type="unfinished"/>
+      <source>Ta&amp;b</source>
+      <extracomment>Displayed as &quot;Tab&quot;. Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
+      <translation>タブ(&amp;B)</translation>
     </message>
     <message>
-        <source>&amp;Search in Project</source>
-        <translation>&amp;プロジェクトで検索</translation>
+      <source>&amp;Search in Project</source>
+      <translation>プロジェクト内を検索(&amp;S)</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ProjectSheet</name>
     <message>
-        <source>Project Manager</source>
-        <extracomment>This string refers to a single project (as in &quot;Manager of a project&quot;).</extracomment>
-        <translation>プロジェクトマネージャ</translation>
+      <source>Project Manager</source>
+      <extracomment>This string refers to a single project (as in &quot;Manager of a project&quot;).</extracomment>
+      <translation>プロジェクトマネージャー</translation>
     </message>
     <message>
-        <source>Edit APK</source>
-        <translation>APKを編集</translation>
+      <source>Edit APK</source>
+      <translation>APK を編集</translation>
     </message>
     <message>
-        <source>Application Title</source>
-        <translation>アプリケーションタイトル</translation>
+      <source>Application Title</source>
+      <translation>アプリのタイトル</translation>
     </message>
     <message>
-        <source>Application Icon</source>
-        <translation>アプリケーションアイコン</translation>
+      <source>Application Icon</source>
+      <translation>アプリのアイコン</translation>
     </message>
     <message>
-        <source>Open Contents</source>
-        <translation>コンテンツを開く</translation>
+      <source>Open Contents</source>
+      <translation>コンテンツを開く</translation>
     </message>
     <message>
-        <source>Save APK</source>
-        <translation>APKを保存</translation>
+      <source>Save APK</source>
+      <translation>APK を保存</translation>
     </message>
     <message>
-        <source>Install APK</source>
-        <translation>APKをインストール</translation>
+      <source>Install APK</source>
+      <translation>APK をインストール</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>RememberDialog</name>
     <message>
-        <source>Don&apos;t show again</source>
-        <translation>二度と表示しない</translation>
+      <source>Don&apos;t show again</source>
+      <translation>今後は表示しない</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ResourceAbstractView</name>
     <message>
-        <source>Edit Resource</source>
-        <translation>リソースを編集</translation>
+      <source>Edit Resource</source>
+      <translation>リソースを編集</translation>
     </message>
     <message>
-        <source>Replace Resource...</source>
-        <translation>リソースを置換...</translation>
+      <source>Replace Resource...</source>
+      <translation>リソースを置換...</translation>
     </message>
     <message>
-        <source>Save Resource As...</source>
-        <translation>リソースに名前を付けて保存...</translation>
+      <source>Save Resource As...</source>
+      <translation>名前を付けてリソースを保存...</translation>
     </message>
     <message>
-        <source>Delete Resource</source>
-        <translation>リソースを削除</translation>
+      <source>Delete Resource</source>
+      <translation>リソースを削除</translation>
     </message>
     <message>
-        <source>Could not remove the resource.</source>
-        <translation>リソースを削除できませんでした。</translation>
+      <source>Could not remove the resource.</source>
+      <translation>リソースを削除できませんでした。</translation>
     </message>
     <message>
-        <source>Open Resource Directory</source>
-        <extracomment>This string refers to a single resource.</extracomment>
-        <translation>リソースディレクトリを開く</translation>
+      <source>Open Resource Directory</source>
+      <extracomment>This string refers to a single resource.</extracomment>
+      <translation>リソースのディレクトリを開く</translation>
     </message>
     <message>
-        <source>Open With</source>
-        <translation>で開く</translation>
+      <source>Open With</source>
+      <translation>開く</translation>
     </message>
     <message>
-        <source>Open With Default Application</source>
-        <translation>デフォルトのアプリケーションで開く</translation>
+      <source>Open With Default Application</source>
+      <translation>既定のアプリで開く</translation>
     </message>
     <message>
-        <source>Choose Another App...</source>
-        <translation>他のアプリを選ぶ...</translation>
+      <source>Choose Another App...</source>
+      <translation>他のアプリを選択...</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ResourceItemsModel</name>
     <message>
-        <source>Resource</source>
-        <translation>リソース</translation>
+      <source>Resource</source>
+      <translation>リソース</translation>
     </message>
     <message>
-        <source>Language</source>
-        <translation>言語</translation>
+      <source>Language</source>
+      <translation>言語</translation>
     </message>
     <message>
-        <source>Locale</source>
-        <translation>場所</translation>
+      <source>Locale</source>
+      <translation>ロケール</translation>
     </message>
     <message>
-        <source>Qualifiers</source>
-        <extracomment>This string refers to the Android qualifiers (https://developer.android.com/guide/topics/resources/providing-resources).</extracomment>
-        <translation>Qualifiers</translation>
+      <source>Qualifiers</source>
+      <extracomment>This string refers to the Android qualifiers (https://developer.android.com/guide/topics/resources/providing-resources).</extracomment>
+      <translation>Qualifiers</translation>
     </message>
     <message>
-        <source>Path</source>
-        <translation>Path</translation>
+      <source>Path</source>
+      <translation>パス</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>SearchModel</name>
     <message>
-        <source>%1 result(s) in %2 file(s)</source>
-        <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
-        <translation>%1 結果(s) in %2 ファイル(s)</translation>
+      <source>%1 result(s) in %2 file(s)</source>
+      <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
+      <translation>%2 個のファイルに %1 件の結果があります</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>SearchSheet</name>
     <message>
-        <source>Searching in %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
-        <translation>で検索しています。 %1</translation>
+      <source>Searching in %1</source>
+      <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
+      <translation>「%1」で検索中です</translation>
     </message>
     <message>
-        <source>Replacing in %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
-        <translation type="unfinished"/>
+      <source>Replacing in %1</source>
+      <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
+      <translation>「%1」で置換中です</translation>
     </message>
     <message>
-        <source>Some occurrences were not replaced.</source>
-        <translation>一部の発生は入れ替わりませんでした。</translation>
+      <source>Some occurrences were not replaced.</source>
+      <translation>いくつかの occurrence は置換されませんでした。</translation>
     </message>
     <message>
-        <source>Found %1 result(s) in %2 file(s)</source>
-        <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
-        <translation type="unfinished"/>
+      <source>Found %1 result(s) in %2 file(s)</source>
+      <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
+      <translation>%2 個のファイルで %1 件の結果がありました</translation>
     </message>
     <message>
-        <source>No results found</source>
-        <translation>結果は見つかりませんでした</translation>
+      <source>No results found</source>
+      <translation>結果が見つかりませんでした</translation>
     </message>
     <message>
-        <source>Replaced %1 occurrence(s) in %2 file(s)</source>
-        <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
-        <translation type="unfinished"/>
+      <source>Replaced %1 occurrence(s) in %2 file(s)</source>
+      <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
+      <translation>%2 個のファイルの %1 件の occurrence を置換しました</translation>
     </message>
     <message>
-        <source>Nothing has been replaced</source>
-        <translation>何も置き換えていません</translation>
+      <source>Nothing has been replaced</source>
+      <translation>何も置換されていません</translation>
     </message>
     <message>
-        <source>Search in Project</source>
-        <translation>プロジェクトで検索</translation>
+      <source>Search in Project</source>
+      <translation>プロジェクト内を検索</translation>
     </message>
     <message>
-        <source>Search for:</source>
-        <translation type="unfinished"/>
+      <source>Search for:</source>
+      <translation>検索:</translation>
     </message>
     <message>
-        <source>Replace with:</source>
-        <translation type="unfinished"/>
+      <source>Replace with:</source>
+      <translation>置換:</translation>
     </message>
     <message>
-        <source>&amp;Search</source>
-        <translation type="unfinished"/>
+      <source>&amp;Search</source>
+      <translation>検索(&amp;S)</translation>
     </message>
     <message>
-        <source>&amp;Replace</source>
-        <translation type="unfinished"/>
+      <source>&amp;Replace</source>
+      <translation>置換(&amp;R)</translation>
     </message>
     <message>
-        <source>Stop</source>
-        <translation>停止</translation>
+      <source>Stop</source>
+      <translation>停止</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>SignatureViewer</name>
     <message>
-        <source>Signatures</source>
-        <translation>署名</translation>
+      <source>Signatures</source>
+      <translation>署名</translation>
     </message>
     <message>
-        <source>JAR signing</source>
-        <extracomment>Read more: https://source.android.com/security/apksigning#v1</extracomment>
-        <translation type="unfinished"/>
+      <source>JAR signing</source>
+      <extracomment>Read more: https://source.android.com/security/apksigning#v1</extracomment>
+      <translation>JAR の署名</translation>
     </message>
     <message>
-        <source>APK Signature Scheme v2</source>
-        <extracomment>Read more: https://source.android.com/security/apksigning/v2</extracomment>
-        <translation>APKシグネチャースキームv2</translation>
+      <source>APK Signature Scheme v2</source>
+      <extracomment>Read more: https://source.android.com/security/apksigning/v2</extracomment>
+      <translation>APK 署名スキーム v2</translation>
     </message>
     <message>
-        <source>APK Signature Scheme v3</source>
-        <extracomment>Read more: https://source.android.com/security/apksigning/v3</extracomment>
-        <translation>APKシグネチャースキームv3</translation>
+      <source>APK Signature Scheme v3</source>
+      <extracomment>Read more: https://source.android.com/security/apksigning/v3</extracomment>
+      <translation>APK 署名スキーム v3</translation>
     </message>
     <message>
-        <source>Signer #%1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a signer index number (e.g., &quot;Signer #1, Signer #7, Signer #42&quot;...).</extracomment>
-        <translation type="unfinished"/>
+      <source>Signer #%1</source>
+      <extracomment>&quot;%1&quot; will be replaced with a signer index number (e.g., &quot;Signer #1, Signer #7, Signer #42&quot;...).</extracomment>
+      <translation>署名 #%1</translation>
     </message>
     <message>
-        <source>Could not retrieve the list of certificates.</source>
-        <translation>証明書のリストを取得できませんでした。</translation>
+      <source>Could not retrieve the list of certificates.</source>
+      <translation>証明書の一覧を取得できませんでした。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>SystemTheme</name>
     <message>
-        <source>System Theme</source>
-        <translation>システムテーマ</translation>
+      <source>System Theme</source>
+      <translation>システムテーマ</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>TitleItemsModel</name>
     <message>
-        <source>Application Title</source>
-        <translation>アプリケーションタイトル</translation>
+      <source>Application Title</source>
+      <translation>アプリのタイトル</translation>
     </message>
     <message>
-        <source>Language</source>
-        <translation>言語</translation>
+      <source>Language</source>
+      <translation>言語</translation>
     </message>
     <message>
-        <source>Qualifiers</source>
-        <extracomment>This string refers to the Android qualifiers (https://developer.android.com/guide/topics/resources/providing-resources).</extracomment>
-        <translation>Qualifiers</translation>
+      <source>Qualifiers</source>
+      <extracomment>This string refers to the Android qualifiers (https://developer.android.com/guide/topics/resources/providing-resources).</extracomment>
+      <translation>Qualifiers</translation>
     </message>
     <message>
-        <source>Path</source>
-        <translation>Path</translation>
+      <source>Path</source>
+      <translation>パス</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>TitleSheet</name>
     <message>
-        <source>Application Title</source>
-        <translation>アプリケーションタイトル</translation>
+      <source>Application Title</source>
+      <translation>アプリのタイトル</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Toolbar</name>
     <message>
-        <source>Customize Toolbar...</source>
-        <translation>ツールバーのカスタマイズ...</translation>
+      <source>Customize Toolbar...</source>
+      <translation>ツールバーのカスタマイズ...</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>ToolbarDialog</name>
     <message>
-        <source>Toolbar Customization</source>
-        <translation>ツールバーカスタマイズ</translation>
+      <source>Toolbar Customization</source>
+      <translation>ツールバーのカスタマイズ</translation>
     </message>
     <message>
-        <source>Current actions:</source>
-        <translation>現在のアクション:</translation>
+      <source>Current actions:</source>
+      <translation>現在のアクション:</translation>
     </message>
     <message>
-        <source>Available actions:</source>
-        <translation>利用可能なアクション:</translation>
+      <source>Available actions:</source>
+      <translation>利用可能なアクション:</translation>
     </message>
     <message>
-        <source>Separator</source>
-        <extracomment>Separator is a toolbar element which divides buttons with a vertical line.</extracomment>
-        <translation>セパレーター</translation>
+      <source>Separator</source>
+      <extracomment>Separator is a toolbar element which divides buttons with a vertical line.</extracomment>
+      <translation>区切り</translation>
     </message>
     <message>
-        <source>Spacer</source>
-        <extracomment>Spacer is a toolbar element which divides buttons with an empty space.</extracomment>
-        <translation>スペーサー</translation>
+      <source>Spacer</source>
+      <extracomment>Spacer is a toolbar element which divides buttons with an empty space.</extracomment>
+      <translation>スペース</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>UpdateDialog</name>
     <message>
-        <source>Updates</source>
-        <translation>アップデート情報</translation>
+      <source>Updates</source>
+      <translation>更新</translation>
     </message>
     <message>
-        <source>Update</source>
-        <extracomment>This is a verb.</extracomment>
-        <translation>アップデート</translation>
+      <source>Update</source>
+      <extracomment>This is a verb.</extracomment>
+      <translation>更新</translation>
     </message>
     <message>
-        <source>Could not check for updates:</source>
-        <translation>更新を確認できませんでした。</translation>
+      <source>Could not check for updates:</source>
+      <translation>更新を確認できませんでした:</translation>
     </message>
     <message>
-        <source>What&apos;s New</source>
-        <translation>新着情報</translation>
+      <source>What&apos;s New</source>
+      <translation>新着情報</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>UpdateItemsModel</name>
     <message>
-        <source>Application</source>
-        <translation>アプリケーション</translation>
+      <source>Application</source>
+      <translation>アプリ</translation>
     </message>
     <message>
-        <source>Current Version</source>
-        <translation>現在のバージョン</translation>
+      <source>Current Version</source>
+      <translation>現在のバージョン</translation>
     </message>
     <message>
-        <source>Latest Version</source>
-        <translation>最新版</translation>
+      <source>Latest Version</source>
+      <translation>最新のバージョン</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>Utils</name>
     <message>
-        <source>Could not save the file.</source>
-        <translation>ファイルを保存できませんでした。</translation>
+      <source>Could not save the file.</source>
+      <translation>ファイルを保存できませんでした。</translation>
     </message>
     <message>
-        <source>Could not replace the file.</source>
-        <translation>ファイルを置き換えることができませんでした。</translation>
+      <source>Could not replace the file.</source>
+      <translation>ファイルを置換できませんでした。</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>WelcomeSheet</name>
     <message>
-        <source>Welcome to the APK Editor Studio.</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; part.</extracomment>
-        <translation>APK Editor Studioへようこそ</translation>
+      <source>Welcome to the APK Editor Studio.</source>
+      <extracomment>Don't translate the &quot;APK Editor Studio&quot; part.</extracomment>
+      <translation>APK Editor Studio へようこそ。</translation>
     </message>
     <message>
-        <source>Open APK</source>
-        <translation>APKを開く</translation>
+      <source>Open APK</source>
+      <translation>APK を開く</translation>
     </message>
     <message>
-        <source>Install APK</source>
-        <translation>APKをインストール</translation>
+      <source>Install APK</source>
+      <translation>APK をインストール</translation>
     </message>
     <message>
-        <source>Support Us</source>
-        <translation>サポートする</translation>
+      <source>Support Us</source>
+      <translation>サポートする</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>XmlNode</name>
     <message>
-        <source>String</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource).</extracomment>
-        <translation>文字列</translation>
+      <source>String</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource).</extracomment>
+      <translation>String</translation>
     </message>
     <message>
-        <source>String array</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource#StringArray).</extracomment>
-        <translation>文字列の配列</translation>
+      <source>String array</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource#StringArray).</extracomment>
+      <translation>String array</translation>
     </message>
     <message>
-        <source>Color</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Color).</extracomment>
-        <translation>Color</translation>
+      <source>Color</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Color).</extracomment>
+      <translation>色</translation>
     </message>
     <message>
-        <source>Dimension</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Dimension).</extracomment>
-        <translation>ディメンション</translation>
+      <source>Dimension</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Dimension).</extracomment>
+      <translation>ディメンション</translation>
     </message>
     <message>
-        <source>Plurals</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource#Plurals).</extracomment>
-        <translation>Plurals</translation>
+      <source>Plurals</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource#Plurals).</extracomment>
+      <translation>Plurals</translation>
     </message>
     <message>
-        <source>ID</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Id).</extracomment>
-        <translation>ID</translation>
+      <source>ID</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Id).</extracomment>
+      <translation>ID</translation>
     </message>
     <message>
-        <source>Integer</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Integer).</extracomment>
-        <translation>整数</translation>
+      <source>Integer</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Integer).</extracomment>
+      <translation>Integer</translation>
     </message>
     <message>
-        <source>Integer Array</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#IntegerArray).</extracomment>
-        <translation>整数配列</translation>
+      <source>Integer Array</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#IntegerArray).</extracomment>
+      <translation>Integer Array</translation>
     </message>
     <message>
-        <source>Array</source>
-        <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#TypedArray).</extracomment>
-        <translation>アレイ</translation>
+      <source>Array</source>
+      <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#TypedArray).</extracomment>
+      <translation>配列</translation>
     </message>
-</context>
-<context>
+  </context>
+  <context>
     <name>YesAlwaysDialog</name>
     <message>
-        <source>Yes, &amp;Always</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>常に&amp;はい</translation>
+      <source>Yes, &amp;Always</source>
+      <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+      <translation>常にはい(&amp;A)</translation>
     </message>
-</context>
+  </context>
 </TS>


### PR DESCRIPTION
However, there are some parts in the source ts that do not have Strings, so some English remains.

![スクリーンショット 2025-02-16 184833](https://github.com/user-attachments/assets/21972143-2591-4550-8ed4-5ec8fe4a1717)
![スクリーンショット 2025-02-16 184844](https://github.com/user-attachments/assets/b4a95742-3a0b-41de-8692-e0b39070cc95)
![スクリーンショット 2025-02-17 081531](https://github.com/user-attachments/assets/63b5e164-629d-431b-97e7-52befae1e335)

Also, why don't you change your translation environment to Crowdin?
