### PR TITLE
Update & Fix French translate. 1.7.2 ver

### DIFF
--- a/src/translations/apk-editor-studio.fr.ts
+++ b/src/translations/apk-editor-studio.fr.ts
@@ -3,7 +3,7 @@
     <name>AboutDialog</name>
     <message>
         <source>About</source>
-        <translation>A propos</translation>
+        <translation>À propos</translation>
     </message>
     <message>
         <source>Authors</source>
@@ -11,7 +11,7 @@
     </message>
     <message>
         <source>Donations</source>
-        <translation type="unfinished"/>
+        <translation>Faire un Don</translation>
     </message>
     <message>
         <source>Version History</source>
@@ -43,11 +43,11 @@
     </message>
     <message>
         <source>Could not fetch the list of donations.</source>
-        <translation type="unfinished"/>
+        <translation>Impossible de récupérer la liste des dons.</translation>
     </message>
     <message>
         <source>Retry</source>
-        <translation type="unfinished"/>
+        <translation>Réessayer</translation>
     </message>
 </context>
 <context>
@@ -58,55 +58,55 @@
     </message>
     <message>
         <source>Screenshot has been successfully created!</source>
-        <translation>La capture d&apos;écran a été créée avec succès!</translation>
+        <translation>La capture d&apos;écran a été créée avec succès !</translation>
     </message>
     <message>
         <source>Could not take a screenshot.</source>
-        <translation>Impossible de prendre une capture d&apos;écran</translation>
+        <translation>Impossible de prendre une capture d&apos;écran.</translation>
     </message>
     <message>
         <source>&amp;Optimize External APK...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Optimiser l&apos;APK externe...</translation>
     </message>
     <message>
         <source>&amp;Sign External APK...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Signer l&apos;APK externe...</translation>
     </message>
     <message>
         <source>&amp;Install External APK...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Installer l&apos;APK externe...</translation>
     </message>
     <message>
         <source>&amp;Find</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Rechercher</translation>
     </message>
     <message>
         <source>Find &amp;Next</source>
-        <translation type="unfinished"/>
+        <translation>Trouver le &amp;suivant</translation>
     </message>
     <message>
         <source>Find Pre&amp;vious</source>
-        <translation type="unfinished"/>
+        <translation>Trouver le &amp;précédent</translation>
     </message>
     <message>
         <source>Find and &amp;Replace</source>
-        <translation type="unfinished"/>
+        <translation>Rerchercher et &amp;remplacer</translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation>Zoom +</translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation>Zoom -</translation>
     </message>
     <message>
         <source>Reset Zoom</source>
-        <translation type="unfinished"/>
+        <translation>Réinitialiser le zoom</translation>
     </message>
     <message>
         <source>Visit &amp;Website</source>
-        <translation>Site internet</translation>
+        <translation>&amp;Site Internet</translation>
     </message>
     <message>
         <source>&amp;Source Code</source>
@@ -114,19 +114,19 @@
     </message>
     <message>
         <source>Make a &amp;Donation</source>
-        <translation>Faire un don</translation>
+        <translation>&amp;Faire un don</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>Quitter</translation>
+        <translation>&amp;Quitter</translation>
     </message>
     <message>
         <source>Check for &amp;Updates</source>
-        <translation>Vérifier les mises à jour</translation>
+        <translation>&amp;Présence de mises à jour</translation>
     </message>
     <message>
         <source>&amp;Reset Settings...</source>
-        <translation>Réinitialiser la configuration...</translation>
+        <translation>&amp;Réinitialiser les paramètres...</translation>
     </message>
     <message>
         <source>&amp;Options...</source>
@@ -135,7 +135,7 @@
     <message>
         <source>&amp;Device Manager...</source>
         <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
-        <translation>&amp;Gestionnaire des appareils...</translation>
+        <translation>&amp;Gestionnaire d&apos;appareils...</translation>
     </message>
     <message>
         <source>&amp;Key Manager...</source>
@@ -148,7 +148,7 @@
     </message>
     <message>
         <source>Take &amp;Screenshot...</source>
-        <translation>Prendre une capture d&apos;écran</translation>
+        <translation>Prendre une ca&amp;pture d&apos;écran...</translation>
     </message>
     <message>
         <source>&amp;Language</source>
@@ -160,16 +160,16 @@
     </message>
     <message>
         <source>Case Sensitive</source>
-        <translation type="unfinished"/>
+        <translation>Sensibile  à la casse</translation>
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation type="unfinished"/>
+        <translation>Expression régulière</translation>
     </message>
     <message>
         <source>&amp;Framework Manager...</source>
         <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
-        <translation type="unfinished"/>
+        <translation>Gestionaire de &amp;Frameworks...</translation>
     </message>
 </context>
 <context>
@@ -189,17 +189,17 @@
     <message>
         <source>Installing %1...</source>
         <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Installation de &quot;%1&quot;...</translation>
     </message>
     <message>
         <source>Successfully installed %1</source>
         <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Installation complète de &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Could not install %1</source>
         <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Impossible d&apos;installer &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Download</source>
@@ -241,12 +241,12 @@
     </message>
     <message>
         <source>Tasks</source>
-        <translation type="unfinished"/>
+        <translation>Tâches</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
         <extracomment>Refers to a menu bar (along with File, View, Window, Help, and similar items).</extracomment>
-        <translation type="unfinished"/>
+        <translation>&amp;Édition</translation>
     </message>
 </context>
 <context>
@@ -284,16 +284,16 @@
     <name>ApkCloner</name>
     <message>
         <source>Updating resource references...</source>
-        <translation type="unfinished"/>
+        <translation>Mise à jour des références de ressources...</translation>
     </message>
     <message>
         <source>Updating Smali references...</source>
-        <extracomment>&quot;Smali&quot; is the name of the tool/format, don't translate it.</extracomment>
-        <translation type="unfinished"/>
+        <extracomment>&quot;Smali&quot; is the name of the tool/format, don&apos;t translate it.</extracomment>
+        <translation>Mise à jour des références Smali...</translation>
     </message>
     <message>
         <source>Updating directory structure...</source>
-        <translation type="unfinished"/>
+        <translation>Mise à jour des structures de répertoire...</translation>
     </message>
 </context>
 <context>
@@ -311,66 +311,66 @@
     <name>BaseFileSheet</name>
     <message>
         <source>&amp;Replace Resource...</source>
-        <translation>&amp;Remplacer ressource...</translation>
+        <translation>&amp;Remplacer la ressource...</translation>
     </message>
     <message>
         <source>&amp;Save Resource</source>
-        <translation>&amp;Sauvegarder ressource</translation>
+        <translation>&amp;Sauvegarder la ressource</translation>
     </message>
     <message>
         <source>Save Resource &amp;As...</source>
-        <translation>Sauvegarder ressource sous...</translation>
+        <translation>Sauvegarder la ressource s&amp;ous...</translation>
     </message>
     <message>
         <source>&amp;Open Resource Directory</source>
         <extracomment>This string refers to a single resource.</extracomment>
-        <translation>&amp;Ouvrir le dossier ressource</translation>
+        <translation>&amp;Ouvrir le dossier &quot;Ressource&quot;</translation>
     </message>
 </context>
 <context>
     <name>CodeSearchBar</name>
     <message>
         <source>No results</source>
-        <translation type="unfinished"/>
+        <translation>Aucun résultat</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation type="unfinished"/>
+        <translation>Rechercher :</translation>
     </message>
     <message>
         <source>Replace:</source>
-        <translation type="unfinished"/>
+        <translation>Remplacer :</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation>Fermer</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="unfinished"/>
+        <translation>Remplacer</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation type="unfinished"/>
+        <translation>Remplacer tout</translation>
     </message>
     <message>
         <source>Hide the Replace Bar</source>
-        <translation type="unfinished"/>
+        <translation>Masquer la barre de remplacement</translation>
     </message>
 </context>
 <context>
     <name>CodeSheet</name>
     <message>
         <source>Would you like to download syntax definitions for this and other formats?</source>
-        <translation type="unfinished"/>
+        <translation>Voulez vous télécharger la syntaxe de définitions pour ce format et pour les autres ?</translation>
     </message>
     <message>
         <source>Downloading syntax definitions...</source>
-        <translation type="unfinished"/>
+        <translation>Téléchargement de la syntaxe de définitions...</translation>
     </message>
     <message>
         <source>Download Syntax Definitions</source>
-        <translation type="unfinished"/>
+        <translation>Télécharger la syntaxe de définitions</translation>
     </message>
 </context>
 <context>
@@ -421,7 +421,7 @@
     </message>
     <message>
         <source>Could not fetch the device list.</source>
-        <translation type="unfinished"/>
+        <translation>Impossible d&apos;optenir la liste des appareils.</translation>
     </message>
     <message>
         <source>Select Device</source>
@@ -432,7 +432,7 @@
     <name>Dialogs</name>
     <message>
         <source>Install APK</source>
-        <translation>Installer APK</translation>
+        <translation>Installer l&apos;APK</translation>
     </message>
     <message>
         <source>Install</source>
@@ -451,22 +451,22 @@
     <name>Downloader</name>
     <message>
         <source>Downloading</source>
-        <translation type="unfinished"/>
+        <translation>Téléchargement</translation>
     </message>
     <message>
         <source>Downloading %1...</source>
         <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Téléchargement de &quot;%1&quot;...</translation>
     </message>
     <message>
         <source>Could not save %1:</source>
         <extracomment>&quot;%1&quot; will be replaced with a title of the saved file.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Impossible d&apos;enregistrer &quot;%1&quot;:</translation>
     </message>
     <message>
         <source>Could not download %1:</source>
         <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Impossible de télécharger &quot;%1&quot;:</translation>
     </message>
 </context>
 <context>
@@ -492,12 +492,12 @@
     <message>
         <source>Framework Manager</source>
         <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
-        <translation type="unfinished"/>
+        <translation>Gestionaire de Framework</translation>
     </message>
     <message>
         <source>&amp;Install</source>
         <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation type="unfinished"/>
+        <translation>&amp;Installer</translation>
     </message>
     <message>
         <source>Remove</source>
@@ -505,24 +505,24 @@
     </message>
     <message>
         <source>Open Directory</source>
-        <translation type="unfinished"/>
+        <translation>Ouvrir le répertoire</translation>
     </message>
     <message>
         <source>Could not install the &quot;%1&quot; framework.</source>
         <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Impossible d&apos;installer le Framework &quot;%1&quot;.</translation>
     </message>
     <message>
         <source>Could not remove the &quot;%1&quot; framework.</source>
         <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Impossible de supprimer le Framework &quot;%1&quot;.</translation>
     </message>
 </context>
 <context>
     <name>IconItemsModel</name>
     <message>
         <source>Round icon</source>
-        <translation>Icone arrondi</translation>
+        <translation>Icône arrondie</translation>
     </message>
     <message>
         <source>TV banner</source>
@@ -581,11 +581,11 @@
     </message>
     <message>
         <source>City or Locality</source>
-        <translation>Ville ou localisation</translation>
+        <translation>Ville ou localité</translation>
     </message>
     <message>
         <source>State or Province</source>
-        <translation>Etat ou province</translation>
+        <translation>État ou province</translation>
     </message>
     <message>
         <source>Country Code</source>
@@ -649,7 +649,7 @@
     </message>
     <message>
         <source>Key password:</source>
-        <translation>Password de la clé :</translation>
+        <translation>Mot de passe de la clé :</translation>
     </message>
 </context>
 <context>
@@ -671,7 +671,7 @@
     </message>
     <message>
         <source>You are using the built-in keystore provided for demonstrational purposes. It can be practical for testing or personal usage. However, if you plan to distribute this APK, we recommend you to specify/create your own keystore via Key Manager.</source>
-        <translation type="unfinished"/>
+        <translation>Vous utilisez le magasin de clés intégré fourni à des fins de démonstration.&lt;br/&gt;Il peut être pratique pour des tests ou un usage personnel.&lt;br/&gt;Cependant, si vous prévoyez de distribuer ce fichier APK, nous vous recommandons de spécifier/créer votre propre magasin de clés via le Gestionnaire de clés.</translation>
     </message>
 </context>
 <context>
@@ -697,18 +697,18 @@
     </message>
     <message>
         <source>Could not read keystore. See details for more information.</source>
-        <translation>Impossible de lire le Keystore : Voir les détails pour plus d&apos;informations.</translation>
+        <translation>Impossible de lire le Keystore.&lt;br/&gt;Voir les détails pour plus d&apos;informations.</translation>
     </message>
 </context>
 <context>
     <name>Keytool::Genkey</name>
     <message>
         <source>Could not write to keystore: alias already exists.</source>
-        <translation>Impossible d&apos;enregistrer le Keystore: l&apos;alias existe déjà.</translation>
+        <translation>Impossible d&apos;enregistrer le Keystore : l&apos;alias existe déjà.</translation>
     </message>
     <message>
         <source>Could not write to keystore. See details for more information.</source>
-        <translation>Impossible d&apos;enregistrer le Keystore: Voir les détails pour plus d&apos;informations</translation>
+        <translation>Impossible d&apos;enregistrer le Keystore.&lt;br/&gt;Voir les détails pour plus d&apos;informations.</translation>
     </message>
 </context>
 <context>
@@ -716,7 +716,7 @@
     <message>
         <source>Log</source>
         <extracomment>&quot;Log&quot; as in event log, message log, etc.</extracomment>
-        <translation>Journal de log</translation>
+        <translation>Journal (log)</translation>
     </message>
 </context>
 <context>
@@ -734,16 +734,16 @@
     <message>
         <source>&amp;Settings</source>
         <extracomment>Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
-        <translation>&amp;Configuration</translation>
+        <translation>&amp;Paramètres</translation>
     </message>
     <message>
         <source>&amp;Window</source>
         <extracomment>Refers to a menu bar (along with File, Edit, View, Help, and similar items).</extracomment>
-        <translation>&amp;Fenêtre</translation>
+        <translation>&amp;Affichage</translation>
     </message>
     <message>
         <source>Tools</source>
-        <translation>Outils</translation>
+        <translation>Barre d&apos;outils</translation>
     </message>
     <message>
         <source>Remove Temporary Files...</source>
@@ -759,7 +759,7 @@
     </message>
     <message>
         <source>File System</source>
-        <translation>Fichier système</translation>
+        <translation>Fichiers système</translation>
     </message>
     <message>
         <source>Manifest</source>
@@ -767,11 +767,11 @@
     </message>
     <message>
         <source>Icons</source>
-        <translation>Icones</translation>
+        <translation>Icônes</translation>
     </message>
     <message>
         <source>Filter</source>
-        <translation type="unfinished"/>
+        <translation>Filtre</translation>
     </message>
     <message>
         <source>&amp;Help</source>
@@ -780,7 +780,7 @@
     </message>
     <message>
         <source>Open &amp;Recent</source>
-        <translation>Ouvrir récent</translation>
+        <translation>Ouvrir les fichiers &amp;récents</translation>
     </message>
     <message>
         <source>&amp;Clear List</source>
@@ -793,21 +793,21 @@
     <message>
         <source>Open &amp;New Window</source>
         <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation type="unfinished"/>
+        <translation>Ouvrir une &amp;nouvelle fenêtre</translation>
     </message>
     <message>
         <source>&amp;About APK Editor Studio...</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; part.</extracomment>
-        <translation>&amp;A propos de APK Editor Studio...</translation>
+        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; part.</extracomment>
+        <translation>&amp;À propos de APK Editor Studio...</translation>
     </message>
     <message>
         <source>About &amp;Qt...</source>
-        <extracomment>Don't translate the &quot;&amp;Qt&quot; part.</extracomment>
-        <translation>A propos de Qt...</translation>
+        <extracomment>Don&apos;t translate the &quot;&amp;Qt&quot; part.</extracomment>
+        <translation>À propos de &amp;Qt...</translation>
     </message>
     <message>
         <source>Welcome</source>
-        <translation type="unfinished"/>
+        <translation>Bienvenue</translation>
     </message>
     <message>
         <source>This APK is already open:
@@ -827,7 +827,7 @@ Voulez-vous les annuler et quitter ?</translation>
     <message>
         <source>%1 not found. Restore the default path?</source>
         <extracomment>&quot;%1&quot; will be replaced with a tool name.</extracomment>
-        <translation type="unfinished"/>
+        <translation>&quot;%1&quot; non trouvé.&lt;br/&gt;Restaurer le chemin par défaut ?</translation>
     </message>
 </context>
 <context>
@@ -865,35 +865,35 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Single-window mode</source>
-        <translation type="unfinished"/>
+        <translation>Mode fenêtre unique</translation>
     </message>
     <message>
         <source>Open .apk files in an existing window</source>
-        <extracomment>Don't translate the &quot;.apk&quot; part.</extracomment>
-        <translation type="unfinished"/>
+        <extracomment>Don&apos;t translate the &quot;.apk&quot; part.</extracomment>
+        <translation>Ouvrir le fichier .apk dans la fenêtre existante</translation>
     </message>
     <message>
         <source>Check for updates automatically</source>
-        <translation>Vérifier les mises à jour automatiquement</translation>
+        <translation>Vérifier automatiquement la présence de mises à jour</translation>
     </message>
     <message>
         <source>Maximum recent files:</source>
-        <translation>Maximum de fichiers récents :</translation>
+        <translation>Nb max de fichiers récents :</translation>
     </message>
     <message>
         <source>Use APK Editor Studio for .apk files</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
-        <translation type="unfinished"/>
+        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
+        <translation>Utiliser APK Editor Studio pour les fichiers .apk</translation>
     </message>
     <message>
         <source>Use APK Editor Studio to open .apk files</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
-        <translation type="unfinished"/>
+        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
+        <translation>Utiliser APK Editor Studio pour ouvrir les fichiers .apk</translation>
     </message>
     <message>
         <source>Add %1 action to Windows Explorer context menu</source>
         <extracomment>&quot;%1&quot; will be replaced with an action name (e.g., Install, Optimize, Sign, etc.).</extracomment>
-        <translation type="unfinished"/>
+        <translation>Ajouter l&apos;action &quot;%1&quot; au menu contextuel de l&apos;Explorateur Windows</translation>
     </message>
     <message>
         <source>Install</source>
@@ -901,12 +901,12 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Optimize</source>
-        <translation type="unfinished"/>
+        <translation>Optimiser</translation>
     </message>
     <message>
         <source>Sign</source>
         <extracomment>This is a verb.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Signer</translation>
     </message>
     <message>
         <source>Language:</source>
@@ -914,7 +914,7 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Theme:</source>
-        <translation type="unfinished"/>
+        <translation>Thème :</translation>
     </message>
     <message>
         <source>Extracted from environment variables by default</source>
@@ -923,7 +923,7 @@ Voulez-vous les annuler et quitter ?</translation>
     <message>
         <source>MB</source>
         <extracomment>Megabytes</extracomment>
-        <translation>MB</translation>
+        <translation>Mo</translation>
     </message>
     <message>
         <source>Default</source>
@@ -936,16 +936,16 @@ Voulez-vous les annuler et quitter ?</translation>
     <message>
         <source>Initial heap size:</source>
         <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Taille initiale du Tag :</translation>
     </message>
     <message>
         <source>Maximum heap size:</source>
         <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Taille maximale du Tag :</translation>
     </message>
     <message>
         <source>Apktool path:</source>
-        <extracomment>&quot;Apktool&quot; is the name of the tool, don't translate it.</extracomment>
+        <extracomment>&quot;Apktool&quot; is the name of the tool, don&apos;t translate it.</extracomment>
         <translation>Chemin de Apktool :</translation>
     </message>
     <message>
@@ -954,65 +954,65 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Frameworks path:</source>
-        <translation>Chemin du Frameworks :</translation>
+        <translation>Chemin des Frameworks :</translation>
     </message>
     <message>
         <source>Unpacking</source>
-        <translation type="unfinished"/>
+        <translation>Décompression</translation>
     </message>
     <message>
         <source>Decompile source code (smali)</source>
-        <extracomment>&quot;Smali&quot; is the name of the tool/format, don't translate it.</extracomment>
-        <translation>Décompiler le code source (smali)</translation>
+        <extracomment>&quot;Smali&quot; is the name of the tool/format, don&apos;t translate it.</extracomment>
+        <translation>Décompiler le code source (Smali)</translation>
     </message>
     <message>
         <source>Decompile broken resources</source>
-        <translation>Décompiler les ressources corrompus</translation>
+        <translation>Décompiler les ressources corrompues</translation>
     </message>
     <message>
         <source>Packing</source>
-        <translation type="unfinished"/>
+        <translation>Compression</translation>
     </message>
     <message>
         <source>Use AAPT2</source>
-        <extracomment>&quot;AAPT2&quot; is the name of the tool, don't translate it.</extracomment>
-        <translation type="unfinished"/>
+        <extracomment>&quot;AAPT2&quot; is the name of the tool, don&apos;t translate it.</extracomment>
+        <translation>Utiliser AAPT2</translation>
     </message>
     <message>
         <source>Pack for debugging</source>
-        <translation type="unfinished"/>
+        <translation>Compresser pour débugger</translation>
     </message>
     <message>
         <source>Sign APK after packing</source>
-        <translation type="unfinished"/>
+        <translation>Signer l&apos;APK après compression</translation>
     </message>
     <message>
         <source>Open Key Manager</source>
         <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
-        <translation>Ouvrir le gestionnaire des clés</translation>
+        <translation>Ouvrir le gestionnaire de clés</translation>
     </message>
     <message>
         <source>Apksigner path:</source>
-        <extracomment>&quot;Apksigner&quot; is the name of the tool, don't translate it.</extracomment>
+        <extracomment>&quot;Apksigner&quot; is the name of the tool, don&apos;t translate it.</extracomment>
         <translation>Chemin de Apksigner :</translation>
     </message>
     <message>
         <source>Optimize APK after packing</source>
-        <translation type="unfinished"/>
+        <translation>Optimiser l&apos;APK après compression</translation>
     </message>
     <message>
         <source>Zipalign path:</source>
-        <extracomment>&quot;Zipalign&quot; is the name of the tool, don't translate it.</extracomment>
+        <extracomment>&quot;Zipalign&quot; is the name of the tool, don&apos;t translate it.</extracomment>
         <translation>Chemin de Zipalign :</translation>
     </message>
     <message>
         <source>Open Device Manager</source>
         <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
-        <translation>Ouvrir le gestionnaire des appareils</translation>
+        <translation>Ouvrir le gestionnaire d&apos;appareils</translation>
     </message>
     <message>
         <source>ADB path:</source>
-        <extracomment>&quot;ADB&quot; is the name of the tool, don't translate it.</extracomment>
+        <extracomment>&quot;ADB&quot; is the name of the tool, don&apos;t translate it.</extracomment>
         <translation>Chemin de ADB :</translation>
     </message>
     <message>
@@ -1021,19 +1021,19 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="unfinished"/>
+        <translation>Apparence</translation>
     </message>
     <message>
         <source>The changes will take effect after the application restart.</source>
-        <translation type="unfinished"/>
+        <translation>Les modifications prendront effet après le redémarrage de l&apos;application.</translation>
     </message>
     <message>
         <source>Open Framework Manager</source>
-        <translation type="unfinished"/>
+        <translation>Ouvrir le gestionaire de Frameworks</translation>
     </message>
     <message>
         <source>Decompile only main classes</source>
-        <translation type="unfinished"/>
+        <translation>Décompiler uniquement les classes principales</translation>
     </message>
 </context>
 <context>
@@ -1044,47 +1044,47 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Error unpacking APK.</source>
-        <translation>Erreur lors de la décompilation APK.</translation>
+        <translation>Erreur lors de la décompilation de l&apos;APK.</translation>
     </message>
     <message>
         <source>Unpacking APK...</source>
-        <translation>Décomplication APK...</translation>
+        <translation>Décomplication de l&apos;APK...</translation>
     </message>
     <message>
         <source>Packing APK...</source>
-        <translation>Compilation APK...</translation>
+        <translation>Compilation de l&apos;APK...</translation>
     </message>
     <message>
         <source>Error packing APK.</source>
-        <translation>Erreur lors de la compilation APK.</translation>
+        <translation>Erreur lors de la compilation de l&apos;APK.</translation>
     </message>
     <message>
         <source>Optimizing APK...</source>
-        <translation>Optimisation APK...</translation>
+        <translation>Optimisation de l&apos;APK...</translation>
     </message>
     <message>
         <source>Error optimizing APK.</source>
-        <translation>Erreur lors de l&apos;optimisation APK.</translation>
+        <translation>Erreur lors de l&apos;optimisation de l&apos;APK.</translation>
     </message>
     <message>
         <source>Signing APK...</source>
-        <translation>Signature APK...</translation>
+        <translation>Signature de l&apos;APK...</translation>
     </message>
     <message>
         <source>Error signing APK.</source>
-        <translation>Erreur lors de la signature APK.</translation>
+        <translation>Erreur lors de la signature de l&apos;APK.</translation>
     </message>
     <message>
         <source>Installing APK...</source>
-        <translation>Installation APK...</translation>
+        <translation>Installation de l&apos;APK...</translation>
     </message>
     <message>
         <source>Error installing APK.</source>
-        <translation>Erreur lors de la signature APK.</translation>
+        <translation>Erreur lors de la signature de l&apos;APK.</translation>
     </message>
     <message>
         <source>Reading APK contents...</source>
-        <translation>Lecture du contenu APK...</translation>
+        <translation>Lecture du contenu de l&apos;APK...</translation>
     </message>
 </context>
 <context>
@@ -1092,7 +1092,7 @@ Voulez-vous les annuler et quitter ?</translation>
     <message>
         <source>Permission Editor</source>
         <extracomment>This string refers to multiple permissions (as in &quot;Editor of permissions&quot;).</extracomment>
-        <translation>Editeur de permission</translation>
+        <translation>Éditeur de permission</translation>
     </message>
     <message>
         <source>Add</source>
@@ -1116,31 +1116,31 @@ Voulez-vous les annuler et quitter ?</translation>
     <name>Project</name>
     <message>
         <source>Package renaming is an experimental function which, in its current state, may lead to crashes and data loss. You can join the discussion and help us improve this feature &lt;a href=&quot;%1&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="unfinished"/>
+        <translation>Le renommage des packages est une fonction expérimentale qui, dans son état actuel, peut entraîner des plantages et des pertes de données.&lt;br/&gt;Vous pouvez participer à la discussion et nous aider à améliorer cette fonctionnalité ici &lt;a href=&quot;%1&quot;&gt;qui&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Cloning the APK requires the source code decompilation to be turned on. Proceed?</source>
-        <translation type="unfinished"/>
+        <translation>Le clonage du fichier APK nécessite l&apos;activation de la décompilation du code source.&lt;br/&gt;Voulez-vous continuer ?</translation>
     </message>
     <message>
         <source>Settings have been applied. Please, reopen this APK.</source>
-        <translation type="unfinished"/>
+        <translation>Les paramètres ont été appliqués.&lt;br/&gt;Veuillez rouvrir ce fichier APK.</translation>
     </message>
     <message>
         <source>Please, reopen this APK in order to unpack the source code and clone the APK.</source>
-        <translation type="unfinished"/>
+        <translation>Veuillez rouvrir ce fichier APK afin de décompresser le code source et cloner l&apos;APK.</translation>
     </message>
     <message>
         <source>Package Name:</source>
-        <translation type="unfinished"/>
+        <translation>Nom du package :</translation>
     </message>
     <message>
         <source>Could not clone the APK.</source>
-        <translation type="unfinished"/>
+        <translation>Impossible de cloner le fichier APK.</translation>
     </message>
     <message>
         <source>APK has been successfully cloned!</source>
-        <translation type="unfinished"/>
+        <translation>Clonage de l&apos;APK avec succès !</translation>
     </message>
     <message>
         <source>Do you want to save changes before packing?</source>
@@ -1152,11 +1152,11 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>The format is not supported.</source>
-        <translation type="unfinished"/>
+        <translation>Le format n&apos;est pas supporté.</translation>
     </message>
     <message>
         <source>Cloning APK</source>
-        <translation type="unfinished"/>
+        <translation>Clonage de l&apos;APK</translation>
     </message>
 </context>
 <context>
@@ -1169,20 +1169,20 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>&amp;Save APK...</source>
-        <translation>&amp;Enregister APK...</translation>
+        <translation>&amp;Enregister l&apos;APK sous...</translation>
     </message>
     <message>
         <source>&amp;Install APK...</source>
-        <translation>&amp;Installer APK...</translation>
+        <translation>&amp;Installer l&apos;APK sur...</translation>
     </message>
     <message>
         <source>O&amp;pen Contents</source>
         <extracomment>Displayed as &quot;Open Contents&quot;.</extracomment>
-        <translation>Ouvrir contenu</translation>
+        <translation>Ou&amp;vrir les contenus</translation>
     </message>
     <message>
         <source>&amp;Close APK</source>
-        <translation>&amp;Fermer APK</translation>
+        <translation>&amp;Fermer l&apos;APK</translation>
     </message>
     <message>
         <source>&amp;Project Manager</source>
@@ -1192,21 +1192,21 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Edit Application &amp;Title</source>
         <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>Modifier le titre de l&apos;application</translation>
+        <translation>Éditer le &amp;titre de l&apos;application</translation>
     </message>
     <message>
         <source>Edit Application &amp;Permissions</source>
         <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>Modifier les permissions de l&apos;application</translation>
+        <translation>Éditer les &amp;permissions de l&apos;application</translation>
     </message>
     <message>
         <source>&amp;Clone APK</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Cloner l&apos;APK</translation>
     </message>
     <message>
         <source>View &amp;Signatures</source>
         <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation type="unfinished"/>
+        <translation>Visualiser la &amp;signature</translation>
     </message>
     <message>
         <source>&amp;Save</source>
@@ -1215,16 +1215,16 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Save &amp;As...</source>
         <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>Sauvegarder sous...</translation>
+        <translation>Sauvegarder s&amp;ous...</translation>
     </message>
     <message>
         <source>Ta&amp;b</source>
         <extracomment>Displayed as &quot;Tab&quot;. Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
-        <translation type="unfinished"/>
+        <translation>&amp;Onglet</translation>
     </message>
     <message>
         <source>&amp;Search in Project</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Rechercher dans le projet</translation>
     </message>
 </context>
 <context>
@@ -1236,7 +1236,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Edit APK</source>
-        <translation>Modifier APK</translation>
+        <translation>Éditer l&apos;APK</translation>
     </message>
     <message>
         <source>Application Title</source>
@@ -1244,7 +1244,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Application Icon</source>
-        <translation>Icone de l&apos;application</translation>
+        <translation>Icône de l&apos;application</translation>
     </message>
     <message>
         <source>Open Contents</source>
@@ -1252,11 +1252,11 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Save APK</source>
-        <translation>Enregister APK</translation>
+        <translation>Enregister l&apos;APK</translation>
     </message>
     <message>
         <source>Install APK</source>
-        <translation>Installer APK</translation>
+        <translation>Installer l&apos;APK</translation>
     </message>
 </context>
 <context>
@@ -1270,19 +1270,19 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>ResourceAbstractView</name>
     <message>
         <source>Edit Resource</source>
-        <translation>Modifier ressource</translation>
+        <translation>Éditer la ressource</translation>
     </message>
     <message>
         <source>Replace Resource...</source>
-        <translation>Remplacer ressource...</translation>
+        <translation>Remplacer la ressource...</translation>
     </message>
     <message>
         <source>Save Resource As...</source>
-        <translation>Sauvegarder ressource en tant que...</translation>
+        <translation>Sauvegarder la ressource sous...</translation>
     </message>
     <message>
         <source>Delete Resource</source>
-        <translation>Supprimer ressource</translation>
+        <translation>Supprimer la ressource</translation>
     </message>
     <message>
         <source>Could not remove the resource.</source>
@@ -1291,19 +1291,19 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Open Resource Directory</source>
         <extracomment>This string refers to a single resource.</extracomment>
-        <translation>Ouvrir le dossier de ressource</translation>
+        <translation>Ouvrir le dossier de la ressource</translation>
     </message>
     <message>
         <source>Open With</source>
-        <translation type="unfinished"/>
+        <translation>Ouvrir avec</translation>
     </message>
     <message>
         <source>Open With Default Application</source>
-        <translation type="unfinished"/>
+        <translation>Ouvrir avec l&apos;application par défaut</translation>
     </message>
     <message>
         <source>Choose Another App...</source>
-        <translation type="unfinished"/>
+        <translation>Choisir une autre application...</translation>
     </message>
 </context>
 <context>
@@ -1335,7 +1335,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>%1 result(s) in %2 file(s)</source>
         <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
-        <translation type="unfinished"/>
+        <translation>&quot;%1&quot; résultat(s) dans &quot;%2&quot; fichier(s)</translation>
     </message>
 </context>
 <context>
@@ -1343,96 +1343,96 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Searching in %1</source>
         <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Recherche dans &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Replacing in %1</source>
         <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
-        <translation type="unfinished"/>
+        <translation>Remplacement dans &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Some occurrences were not replaced.</source>
-        <translation type="unfinished"/>
+        <translation>Certaines occurrences n&apos;ont pas été remplacées.</translation>
     </message>
     <message>
         <source>Found %1 result(s) in %2 file(s)</source>
         <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
-        <translation type="unfinished"/>
+        <translation>&quot;%1&quot; résultat(s) trouvé(s) dans &quot;%2&quot; fichier(s)</translation>
     </message>
     <message>
         <source>No results found</source>
-        <translation type="unfinished"/>
+        <translation>Aucun résultat trouvé</translation>
     </message>
     <message>
         <source>Replaced %1 occurrence(s) in %2 file(s)</source>
         <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
-        <translation type="unfinished"/>
+        <translation>&quot;%1&quot; occorrence(s) remplacée(s) dans &quot;%2&quot; fichier(s)</translation>
     </message>
     <message>
         <source>Nothing has been replaced</source>
-        <translation type="unfinished"/>
+        <translation>Rien n&apos;a été remplacé</translation>
     </message>
     <message>
         <source>Search in Project</source>
-        <translation type="unfinished"/>
+        <translation>Chercher dans le projet</translation>
     </message>
     <message>
         <source>Search for:</source>
-        <translation type="unfinished"/>
+        <translation>Rechercher :</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation type="unfinished"/>
+        <translation>Remplacer par :</translation>
     </message>
     <message>
         <source>&amp;Search</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Rechercher</translation>
     </message>
     <message>
         <source>&amp;Replace</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Remplacer</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="unfinished"/>
+        <translation>Arrêter</translation>
     </message>
 </context>
 <context>
     <name>SignatureViewer</name>
     <message>
         <source>Signatures</source>
-        <translation type="unfinished"/>
+        <translation>Signatures</translation>
     </message>
     <message>
         <source>JAR signing</source>
         <extracomment>Read more: https://source.android.com/security/apksigning#v1</extracomment>
-        <translation type="unfinished"/>
+        <translation>Signatures JAR</translation>
     </message>
     <message>
         <source>APK Signature Scheme v2</source>
         <extracomment>Read more: https://source.android.com/security/apksigning/v2</extracomment>
-        <translation type="unfinished"/>
+        <translation>Schéma de signatures APK v2</translation>
     </message>
     <message>
         <source>APK Signature Scheme v3</source>
         <extracomment>Read more: https://source.android.com/security/apksigning/v3</extracomment>
-        <translation type="unfinished"/>
+        <translation>Schéma de signatures APK v3</translation>
     </message>
     <message>
         <source>Signer #%1</source>
         <extracomment>&quot;%1&quot; will be replaced with a signer index number (e.g., &quot;Signer #1, Signer #7, Signer #42&quot;...).</extracomment>
-        <translation type="unfinished"/>
+        <translation>Signature #%1</translation>
     </message>
     <message>
         <source>Could not retrieve the list of certificates.</source>
-        <translation type="unfinished"/>
+        <translation>Impossible d&apos;optenir la liste des certificats.</translation>
     </message>
 </context>
 <context>
     <name>SystemTheme</name>
     <message>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation>Thème du système</translation>
     </message>
 </context>
 <context>
@@ -1466,22 +1466,22 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>Toolbar</name>
     <message>
         <source>Customize Toolbar...</source>
-        <translation type="unfinished"/>
+        <translation>Personalisation de la barre d&apos;outils...</translation>
     </message>
 </context>
 <context>
     <name>ToolbarDialog</name>
     <message>
         <source>Toolbar Customization</source>
-        <translation type="unfinished"/>
+        <translation>Personalisation de la barre d&apos;instruments</translation>
     </message>
     <message>
         <source>Current actions:</source>
-        <translation type="unfinished"/>
+        <translation>Action courante :</translation>
     </message>
     <message>
         <source>Available actions:</source>
-        <translation type="unfinished"/>
+        <translation>Actions disponibles :</translation>
     </message>
     <message>
         <source>Separator</source>
@@ -1491,23 +1491,23 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Spacer</source>
         <extracomment>Spacer is a toolbar element which divides buttons with an empty space.</extracomment>
-        <translation>Espace</translation>
+        <translation>Espaceur</translation>
     </message>
 </context>
 <context>
     <name>UpdateDialog</name>
     <message>
         <source>Updates</source>
-        <translation type="unfinished"/>
+        <translation>Mises à jour</translation>
     </message>
     <message>
         <source>Update</source>
         <extracomment>This is a verb.</extracomment>
-        <translation>Actualiser</translation>
+        <translation>Mettre à jour</translation>
     </message>
     <message>
         <source>Could not check for updates:</source>
-        <translation>Impossible de rechercher les mises à jour:</translation>
+        <translation>Impossible de rechercher les mises à jour :</translation>
     </message>
     <message>
         <source>What&apos;s New</source>
@@ -1522,11 +1522,11 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>Version installée</translation>
     </message>
     <message>
         <source>Latest Version</source>
-        <translation type="unfinished"/>
+        <translation>Dernière version</translation>
     </message>
 </context>
 <context>
@@ -1544,20 +1544,20 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>WelcomeSheet</name>
     <message>
         <source>Welcome to the APK Editor Studio.</source>
-        <extracomment>Don't translate the &quot;APK Editor Studio&quot; part.</extracomment>
+        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; part.</extracomment>
         <translation>Bienvenue dans APK Editor Studio.</translation>
     </message>
     <message>
         <source>Open APK</source>
-        <translation>Ouvrir APK</translation>
+        <translation>Ouvrir l&apos;APK</translation>
     </message>
     <message>
         <source>Install APK</source>
-        <translation>Installer APK</translation>
+        <translation>Installer l&apos;APK</translation>
     </message>
     <message>
         <source>Support Us</source>
-        <translation type="unfinished"/>
+        <translation>Supportez nous</translation>
     </message>
 </context>
 <context>
@@ -1565,17 +1565,17 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>String</source>
         <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource).</extracomment>
-        <translation>String</translation>
+        <translation>Chaîne</translation>
     </message>
     <message>
         <source>String array</source>
         <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource#StringArray).</extracomment>
-        <translation>String array</translation>
+        <translation>Matrice de chaîne</translation>
     </message>
     <message>
         <source>Color</source>
         <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Color).</extracomment>
-        <translation>Color</translation>
+        <translation>Couleur</translation>
     </message>
     <message>
         <source>Dimension</source>
@@ -1585,7 +1585,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Plurals</source>
         <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/string-resource#Plurals).</extracomment>
-        <translation>Plurals</translation>
+        <translation>Pluriels</translation>
     </message>
     <message>
         <source>ID</source>
@@ -1595,17 +1595,17 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Integer</source>
         <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#Integer).</extracomment>
-        <translation>Integer</translation>
+        <translation>Entier</translation>
     </message>
     <message>
         <source>Integer Array</source>
         <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#IntegerArray).</extracomment>
-        <translation>Integer Array</translation>
+        <translation>Matrice des entiers</translation>
     </message>
     <message>
         <source>Array</source>
         <extracomment>This string refers to the Android resource type (https://developer.android.com/guide/topics/resources/more-resources#TypedArray).</extracomment>
-        <translation>Array</translation>
+        <translation>Matrice</translation>
     </message>
 </context>
 <context>
@@ -1613,7 +1613,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <message>
         <source>Yes, &amp;Always</source>
         <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
-        <translation>Oui, toujours</translation>
+        <translation>Oui, tou&amp;jours</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/apk-editor-studio.fr.ts
+++ b/src/translations/apk-editor-studio.fr.ts
@@ -134,12 +134,12 @@
     </message>
     <message>
         <source>&amp;Device Manager...</source>
-        <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
+        <extracomment>This string refers to multiple devices (as in 'Manager of devices').</extracomment>
         <translation>&amp;Gestionnaire d&apos;appareils...</translation>
     </message>
     <message>
         <source>&amp;Key Manager...</source>
-        <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
+        <extracomment>This string refers to multiple keys (as in 'Manager of keys').</extracomment>
         <translation>&amp;Gestionnaire de clés...</translation>
     </message>
     <message>
@@ -156,7 +156,7 @@
     </message>
     <message>
         <source>&amp;Open APK...</source>
-        <translation>&amp;Ouvrir un APK...</translation>
+        <translation>&amp;Ouvrir l&apos;APK &amp;&amp; décompiler...</translation>
     </message>
     <message>
         <source>Case Sensitive</source>
@@ -168,7 +168,7 @@
     </message>
     <message>
         <source>&amp;Framework Manager...</source>
-        <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
+        <extracomment>This string refers to multiple frameworks (as in 'Manager of frameworks').</extracomment>
         <translation>Gestionaire de &amp;Frameworks...</translation>
     </message>
 </context>
@@ -188,17 +188,17 @@
     </message>
     <message>
         <source>Installing %1...</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
+        <extracomment>'%1' will be replaced with a path to the APK.</extracomment>
         <translation>Installation de &quot;%1&quot;...</translation>
     </message>
     <message>
         <source>Successfully installed %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
+        <extracomment>'%1' will be replaced with a path to the APK.</extracomment>
         <translation>Installation complète de &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Could not install %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the APK.</extracomment>
+        <extracomment>'%1' will be replaced with a path to the APK.</extracomment>
         <translation>Impossible d&apos;installer &quot;%1&quot;</translation>
     </message>
     <message>
@@ -288,7 +288,7 @@
     </message>
     <message>
         <source>Updating Smali references...</source>
-        <extracomment>&quot;Smali&quot; is the name of the tool/format, don&apos;t translate it.</extracomment>
+        <extracomment>'Smali' is the name of the tool/format, don't translate it.</extracomment>
         <translation>Mise à jour des références Smali...</translation>
     </message>
     <message>
@@ -324,7 +324,7 @@
     <message>
         <source>&amp;Open Resource Directory</source>
         <extracomment>This string refers to a single resource.</extracomment>
-        <translation>&amp;Ouvrir le dossier &quot;Ressource&quot;</translation>
+        <translation>&amp;Ouvrir le dossier de la ressource</translation>
     </message>
 </context>
 <context>
@@ -400,7 +400,7 @@
     <name>DeviceManager</name>
     <message>
         <source>Device Manager</source>
-        <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
+        <extracomment>This string refers to multiple devices (as in 'Manager of devices').</extracomment>
         <translation>Gestionnaire des appareils</translation>
     </message>
     <message>
@@ -455,17 +455,17 @@
     </message>
     <message>
         <source>Downloading %1...</source>
-        <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
+        <extracomment>'%1' will be replaced with a title of the downloaded file.</extracomment>
         <translation>Téléchargement de &quot;%1&quot;...</translation>
     </message>
     <message>
         <source>Could not save %1:</source>
-        <extracomment>&quot;%1&quot; will be replaced with a title of the saved file.</extracomment>
+        <extracomment>'%1' will be replaced with a title of the saved file.</extracomment>
         <translation>Impossible d&apos;enregistrer &quot;%1&quot;:</translation>
     </message>
     <message>
         <source>Could not download %1:</source>
-        <extracomment>&quot;%1&quot; will be replaced with a title of the downloaded file.</extracomment>
+        <extracomment>'%1' will be replaced with a title of the downloaded file.</extracomment>
         <translation>Impossible de télécharger &quot;%1&quot;:</translation>
     </message>
 </context>
@@ -491,12 +491,12 @@
     <name>FrameworkManager</name>
     <message>
         <source>Framework Manager</source>
-        <extracomment>This string refers to multiple frameworks (as in &quot;Manager of frameworks&quot;).</extracomment>
+        <extracomment>This string refers to multiple frameworks (as in 'Manager of frameworks').</extracomment>
         <translation>Gestionaire de Framework</translation>
     </message>
     <message>
         <source>&amp;Install</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+        <extracomment>The '&amp;' is a shortcut key prefix, not an 'and' conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
         <translation>&amp;Installer</translation>
     </message>
     <message>
@@ -509,12 +509,12 @@
     </message>
     <message>
         <source>Could not install the &quot;%1&quot; framework.</source>
-        <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
+        <extracomment>'%1' will be replaced with a framework file name.</extracomment>
         <translation>Impossible d&apos;installer le Framework &quot;%1&quot;.</translation>
     </message>
     <message>
         <source>Could not remove the &quot;%1&quot; framework.</source>
-        <extracomment>&quot;%1&quot; will be replaced with a framework file name.</extracomment>
+        <extracomment>'%1' will be replaced with a framework file name.</extracomment>
         <translation>Impossible de supprimer le Framework &quot;%1&quot;.</translation>
     </message>
 </context>
@@ -715,7 +715,7 @@
     <name>LogView</name>
     <message>
         <source>Log</source>
-        <extracomment>&quot;Log&quot; as in event log, message log, etc.</extracomment>
+        <extracomment>'Log' as in event log, message log, etc.</extracomment>
         <translation>Journal (log)</translation>
     </message>
 </context>
@@ -792,17 +792,17 @@
     </message>
     <message>
         <source>Open &amp;New Window</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+        <extracomment>The '&amp;' is a shortcut key prefix, not an 'and' conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
         <translation>Ouvrir une &amp;nouvelle fenêtre</translation>
     </message>
     <message>
         <source>&amp;About APK Editor Studio...</source>
-        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; part.</extracomment>
+        <extracomment>Don't translate the 'APK Editor Studio' part.</extracomment>
         <translation>&amp;À propos de APK Editor Studio...</translation>
     </message>
     <message>
         <source>About &amp;Qt...</source>
-        <extracomment>Don&apos;t translate the &quot;&amp;Qt&quot; part.</extracomment>
+        <extracomment>Don't translate the 'Qt' part.</extracomment>
         <translation>À propos de &amp;Qt...</translation>
     </message>
     <message>
@@ -813,7 +813,7 @@
         <source>This APK is already open:
 %1
 Do you want to reopen it and lose any unsaved changes?</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to an APK.</extracomment>
+        <extracomment>'%1' will be replaced with a path to an APK.</extracomment>
         <translation>Cet APK est déjà ouvert :
 %1
 Voulez-vous le rouvrir et perdre les modifications non enregistrées ?</translation>
@@ -826,7 +826,7 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>%1 not found. Restore the default path?</source>
-        <extracomment>&quot;%1&quot; will be replaced with a tool name.</extracomment>
+        <extracomment>'%1' will be replaced with a tool name.</extracomment>
         <translation>&quot;%1&quot; non trouvé.&lt;br/&gt;Restaurer le chemin par défaut ?</translation>
     </message>
 </context>
@@ -869,7 +869,7 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Open .apk files in an existing window</source>
-        <extracomment>Don&apos;t translate the &quot;.apk&quot; part.</extracomment>
+        <extracomment>Don't translate the '.apk'; part.</extracomment>
         <translation>Ouvrir le fichier .apk dans la fenêtre existante</translation>
     </message>
     <message>
@@ -882,17 +882,17 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Use APK Editor Studio for .apk files</source>
-        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
+        <extracomment>Don't translate the 'APK Editor Studio' and '.apk' parts.</extracomment>
         <translation>Utiliser APK Editor Studio pour les fichiers .apk</translation>
     </message>
     <message>
         <source>Use APK Editor Studio to open .apk files</source>
-        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; and &quot;.apk&quot; parts.</extracomment>
+        <extracomment>Don't translate the 'APK Editor Studio' and '.apk' parts.</extracomment>
         <translation>Utiliser APK Editor Studio pour ouvrir les fichiers .apk</translation>
     </message>
     <message>
         <source>Add %1 action to Windows Explorer context menu</source>
-        <extracomment>&quot;%1&quot; will be replaced with an action name (e.g., Install, Optimize, Sign, etc.).</extracomment>
+        <extracomment>'%1' will be replaced with an action name (e.g., Install, Optimize, Sign, etc.).</extracomment>
         <translation>Ajouter l&apos;action &quot;%1&quot; au menu contextuel de l&apos;Explorateur Windows</translation>
     </message>
     <message>
@@ -935,17 +935,17 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Initial heap size:</source>
-        <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
+        <extracomment>'Heap' refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
         <translation>Taille initiale du Tag :</translation>
     </message>
     <message>
         <source>Maximum heap size:</source>
-        <extracomment>&quot;Heap&quot; refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
+        <extracomment>'Heap' refers to a memory heap. If there is no clear translation in your language, you may also put the original English word in the parentheses.</extracomment>
         <translation>Taille maximale du Tag :</translation>
     </message>
     <message>
         <source>Apktool path:</source>
-        <extracomment>&quot;Apktool&quot; is the name of the tool, don&apos;t translate it.</extracomment>
+        <extracomment>'Apktool' is the name of the tool, don't translate it.</extracomment>
         <translation>Chemin de Apktool :</translation>
     </message>
     <message>
@@ -962,7 +962,7 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Decompile source code (smali)</source>
-        <extracomment>&quot;Smali&quot; is the name of the tool/format, don&apos;t translate it.</extracomment>
+        <extracomment>"Smali" is the name of the tool/format, don't translate it.</extracomment>
         <translation>Décompiler le code source (Smali)</translation>
     </message>
     <message>
@@ -975,7 +975,7 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Use AAPT2</source>
-        <extracomment>&quot;AAPT2&quot; is the name of the tool, don&apos;t translate it.</extracomment>
+        <extracomment>"AAPT2" is the name of the tool, don't translate it.</extracomment>
         <translation>Utiliser AAPT2</translation>
     </message>
     <message>
@@ -988,12 +988,12 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Open Key Manager</source>
-        <extracomment>This string refers to multiple keys (as in &quot;Manager of keys&quot;).</extracomment>
+        <extracomment>This string refers to multiple keys (as in 'Manager of keys').</extracomment>
         <translation>Ouvrir le gestionnaire de clés</translation>
     </message>
     <message>
         <source>Apksigner path:</source>
-        <extracomment>&quot;Apksigner&quot; is the name of the tool, don&apos;t translate it.</extracomment>
+        <extracomment>"Apksigner" is the name of the tool, don't translate it.</extracomment>
         <translation>Chemin de Apksigner :</translation>
     </message>
     <message>
@@ -1002,17 +1002,17 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Zipalign path:</source>
-        <extracomment>&quot;Zipalign&quot; is the name of the tool, don&apos;t translate it.</extracomment>
+        <extracomment>"Zipalign" is the name of the tool, don't translate it.</extracomment>
         <translation>Chemin de Zipalign :</translation>
     </message>
     <message>
         <source>Open Device Manager</source>
-        <extracomment>This string refers to multiple devices (as in &quot;Manager of devices&quot;).</extracomment>
+        <extracomment>This string refers to multiple devices (as in 'Manager of devices').</extracomment>
         <translation>Ouvrir le gestionnaire d&apos;appareils</translation>
     </message>
     <message>
         <source>ADB path:</source>
-        <extracomment>&quot;ADB&quot; is the name of the tool, don&apos;t translate it.</extracomment>
+        <extracomment>'ADB' is the name of the tool, don't translate it.</extracomment>
         <translation>Chemin de ADB :</translation>
     </message>
     <message>
@@ -1091,7 +1091,7 @@ Voulez-vous les annuler et quitter ?</translation>
     <name>PermissionEditor</name>
     <message>
         <source>Permission Editor</source>
-        <extracomment>This string refers to multiple permissions (as in &quot;Editor of permissions&quot;).</extracomment>
+        <extracomment>This string refers to multiple permissions (as in 'Editor of permissions').</extracomment>
         <translation>Éditeur de permission</translation>
     </message>
     <message>
@@ -1108,7 +1108,7 @@ Voulez-vous les annuler et quitter ?</translation>
     </message>
     <message>
         <source>Are you sure you want to remove the %1 permission?</source>
-        <extracomment>%1 will be replaced with a programmatic Android permission name (e.g., &quot;android.permission.SEND_SMS&quot;, &quot;android.permission.CAMERA&quot;, etc.).</extracomment>
+        <extracomment>'%1' will be replaced with a programmatic Android permission name (e.g., 'android.permission.SEND_SMS', 'android.permission.CAMERA', etc.).</extracomment>
         <translation>Voulez-vous vraiment supprimer l&apos;autorisation %1 ?</translation>
     </message>
 </context>
@@ -1177,7 +1177,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>O&amp;pen Contents</source>
-        <extracomment>Displayed as &quot;Open Contents&quot;.</extracomment>
+        <extracomment>Displayed as 'Open Contents'.</extracomment>
         <translation>Ou&amp;vrir les contenus</translation>
     </message>
     <message>
@@ -1186,17 +1186,17 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>&amp;Project Manager</source>
-        <extracomment>This string refers to a single project (as in &quot;Manager of a project&quot;).</extracomment>
+        <extracomment>This string refers to a single project (as in 'Manager of a project').</extracomment>
         <translation>&amp;Gestion du projet</translation>
     </message>
     <message>
         <source>Edit Application &amp;Title</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+        <extracomment>The '&amp;' is a shortcut key prefix, not an 'and' conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
         <translation>Éditer le &amp;titre de l&apos;application</translation>
     </message>
     <message>
         <source>Edit Application &amp;Permissions</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+        <extracomment>The '&amp;' is a shortcut key prefix, not an 'and' conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
         <translation>Éditer les &amp;permissions de l&apos;application</translation>
     </message>
     <message>
@@ -1205,7 +1205,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>View &amp;Signatures</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+        <extracomment>The '&amp;' is a shortcut key prefix, not an 'and' conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
         <translation>Visualiser la &amp;signature</translation>
     </message>
     <message>
@@ -1214,12 +1214,12 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+        <extracomment>The '&amp;' is a shortcut key prefix, not an 'and' conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
         <translation>Sauvegarder s&amp;ous...</translation>
     </message>
     <message>
         <source>Ta&amp;b</source>
-        <extracomment>Displayed as &quot;Tab&quot;. Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
+        <extracomment>Displayed as 'Tab'. Refers to a menu bar (along with File, Edit, View, Window, Help, and similar items).</extracomment>
         <translation>&amp;Onglet</translation>
     </message>
     <message>
@@ -1231,7 +1231,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>ProjectSheet</name>
     <message>
         <source>Project Manager</source>
-        <extracomment>This string refers to a single project (as in &quot;Manager of a project&quot;).</extracomment>
+        <extracomment>This string refers to a single project (as in 'Manager of a project').</extracomment>
         <translation>Gestionnaire de projet</translation>
     </message>
     <message>
@@ -1262,7 +1262,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
 <context>
     <name>RememberDialog</name>
     <message>
-        <source>Don&apos;t show again</source>
+        <source>Don't show again</source>
         <translation>Ne plus montrer</translation>
     </message>
 </context>
@@ -1334,7 +1334,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>SearchModel</name>
     <message>
         <source>%1 result(s) in %2 file(s)</source>
-        <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
+        <extracomment>'%1' and '%2' will be replaced with arbitrary numbers representing the search results.</extracomment>
         <translation>&quot;%1&quot; résultat(s) dans &quot;%2&quot; fichier(s)</translation>
     </message>
 </context>
@@ -1342,12 +1342,12 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>SearchSheet</name>
     <message>
         <source>Searching in %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
+        <extracomment>'%1' will be replaced with a path to the file.</extracomment>
         <translation>Recherche dans &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Replacing in %1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a path to the file.</extracomment>
+        <extracomment>'%1' will be replaced with a path to the file.</extracomment>
         <translation>Remplacement dans &quot;%1&quot;</translation>
     </message>
     <message>
@@ -1356,7 +1356,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Found %1 result(s) in %2 file(s)</source>
-        <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
+        <extracomment>'%1' and '%2' will be replaced with arbitrary numbers representing the search results.</extracomment>
         <translation>&quot;%1&quot; résultat(s) trouvé(s) dans &quot;%2&quot; fichier(s)</translation>
     </message>
     <message>
@@ -1365,7 +1365,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Replaced %1 occurrence(s) in %2 file(s)</source>
-        <extracomment>&quot;%1&quot; and &quot;%2&quot; will be replaced with arbitrary numbers representing the search results.</extracomment>
+        <extracomment>'%1' and '%2' will be replaced with arbitrary numbers representing the search results.</extracomment>
         <translation>&quot;%1&quot; occorrence(s) remplacée(s) dans &quot;%2&quot; fichier(s)</translation>
     </message>
     <message>
@@ -1420,7 +1420,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     </message>
     <message>
         <source>Signer #%1</source>
-        <extracomment>&quot;%1&quot; will be replaced with a signer index number (e.g., &quot;Signer #1, Signer #7, Signer #42&quot;...).</extracomment>
+        <extracomment>'%1' will be replaced with a signer index number (e.g., 'Signer #1, Signer #7, Signer #42'...).</extracomment>
         <translation>Signature #%1</translation>
     </message>
     <message>
@@ -1544,7 +1544,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>WelcomeSheet</name>
     <message>
         <source>Welcome to the APK Editor Studio.</source>
-        <extracomment>Don&apos;t translate the &quot;APK Editor Studio&quot; part.</extracomment>
+        <extracomment>Don't translate the 'APK Editor Studio' part.</extracomment>
         <translation>Bienvenue dans APK Editor Studio.</translation>
     </message>
     <message>
@@ -1612,7 +1612,7 @@ Toutes les modifications non enregistrées seront perdues.</translation>
     <name>YesAlwaysDialog</name>
     <message>
         <source>Yes, &amp;Always</source>
-        <extracomment>The &quot;&amp;&quot; is a shortcut key prefix, not an &quot;and&quot; conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
+        <extracomment>The '&amp;' is a shortcut key prefix, not an 'and' conjunction. Details: https://github.com/kefir500/apk-editor-studio/wiki/Translation-Guide#shortcuts</extracomment>
         <translation>Oui, tou&amp;jours</translation>
     </message>
 </context>


### PR DESCRIPTION
French language update
I hope my corrections and additions will be appreciated. I tried to translate the entire program, but I was unable to translate a few lines of text in the settings section.
In the 'Appearance' tab:
"Code Editor Font: " and "Code Editor Font Size: "
In the 'Apktool' tab:
"Decompile without debug info: "
I was also unable to translate the term "Word Wrap" in the "Tabs" menu.

Best regards